### PR TITLE
[feat] : 팔로워/팔로잉 조회 페이지 출력 기능

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/common/dto/DTOEX.java
+++ b/src/main/java/io/github/nokasegu/post_here/common/dto/DTOEX.java
@@ -1,4 +1,0 @@
-package io.github.nokasegu.post_here.common.dto;
-
-public class DTOEX {
-}

--- a/src/main/java/io/github/nokasegu/post_here/follow/controller/FollowingApiController.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/controller/FollowingApiController.java
@@ -1,0 +1,119 @@
+package io.github.nokasegu.post_here.follow.controller;
+
+import io.github.nokasegu.post_here.follow.dto.FollowingStatusRequestDto;
+import io.github.nokasegu.post_here.follow.dto.FollowingStatusResponseDto;
+import io.github.nokasegu.post_here.follow.dto.UserBriefResponseDto;
+import io.github.nokasegu.post_here.follow.service.FollowingService;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/friends")
+public class FollowingApiController {
+
+    private final FollowingService followingService;
+    private final UserInfoRepository userInfoRepository;
+
+    /**
+     * 현재 사용자 PK 해석 규칙
+     * 1) 개발용 헤더 X-USER-ID(숫자) 있으면 최우선 사용
+     * 2) principal.getName()이 숫자면 그대로 PK
+     * 3) 문자열이면 loginId로 간주 후 조회 → PK
+     * <p>
+     * 🚀 새 ERD(이메일 기준)로 전환하면 아래 3) 분기를 이 한 줄로 바꾸세요:
+     * Long id = userInfoRepository.findByEmail(name)
+     * .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자(email) 없음: " + name))
+     * .getId();
+     * return id;
+     */
+    private Long resolveUserId(Principal principal, Long overrideHeader) {
+        if (overrideHeader != null) return overrideHeader;
+
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        String name = principal.getName();
+        try {
+            return Long.valueOf(name); // 숫자면 PK로 간주
+        } catch (NumberFormatException ignore) {
+            // 로그인 아이디로 조회 (현재 DB/코드 호환용)
+            UserInfoEntity user = userInfoRepository.findByLoginId(name);
+            if (user == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자(loginId) 없음: " + name);
+            return user.getId();
+        }
+    }
+
+    // ===== Followers (로그인 사용자 기준)
+    @GetMapping("/followers")
+    public Page<UserBriefResponseDto> followers(
+            Principal principal,
+            @RequestHeader(name = "X-USER-ID", required = false) Long userHeader,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long me = resolveUserId(principal, userHeader);
+        return followingService
+                .getFollowers(me, PageRequest.of(page, size))
+                .map(UserBriefResponseDto::convertToDto);
+    }
+
+    // (개발/테스트용) 임의 사용자 기준
+    @GetMapping("/followers/{userId}")
+    public Page<UserBriefResponseDto> followersById(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return followingService
+                .getFollowers(userId, PageRequest.of(page, size))
+                .map(UserBriefResponseDto::convertToDto);
+    }
+
+    // ===== Followings (로그인 사용자 기준)
+    @GetMapping("/followings")
+    public Page<UserBriefResponseDto> followings(
+            Principal principal,
+            @RequestHeader(name = "X-USER-ID", required = false) Long userHeader,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long me = resolveUserId(principal, userHeader);
+        return followingService
+                .getFollowings(me, PageRequest.of(page, size))
+                .map(UserBriefResponseDto::convertToDto);
+    }
+
+    // (개발/테스트용) 임의 사용자 기준
+    @GetMapping("/followings/{userId}")
+    public Page<UserBriefResponseDto> followingsById(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return followingService
+                .getFollowings(userId, PageRequest.of(page, size))
+                .map(UserBriefResponseDto::convertToDto);
+    }
+
+    // ===== 배치 상태: ids 중 내가 팔로우한 대상은 true
+    @PostMapping("/status")
+    public FollowingStatusResponseDto status(
+            Principal principal,
+            @RequestHeader(name = "X-USER-ID", required = false) Long userHeader,
+            @RequestBody FollowingStatusRequestDto req
+    ) {
+        Long me = resolveUserId(principal, userHeader);
+        return FollowingStatusResponseDto.from(
+                followingService.getFollowingStatus(me, req.getIds())
+        );
+    }
+}

--- a/src/main/java/io/github/nokasegu/post_here/follow/controller/FollowingController.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/controller/FollowingController.java
@@ -1,13 +1,17 @@
 package io.github.nokasegu.post_here.follow.controller;
 
-import io.github.nokasegu.post_here.follow.service.FollowingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @RequiredArgsConstructor
 public class FollowingController {
 
-    private final FollowingService followingService;
-
+    // 친구 목록 단일 페이지 (탭으로 Follower/Following/Search 전환)
+    @GetMapping("/friends")
+    public String friendsPage() {
+        // src/main/resources/templates/follow/friends.html
+        return "follow/friends";
+    }
 }

--- a/src/main/java/io/github/nokasegu/post_here/follow/dto/FollowingStatusRequestDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/dto/FollowingStatusRequestDto.java
@@ -1,0 +1,22 @@
+package io.github.nokasegu.post_here.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 배치 상태 요청 */
+/** 화면에 표시 중인 사용자 id 목록을 서버로 보냄 */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FollowingStatusRequestDto {
+
+    private List<Long> ids;  // ← getIds()를 위해 @Getter 필수
+
+    public static Object convertToEntity(FollowingStatusRequestDto d) { return null; }
+    public static FollowingStatusRequestDto convertToDto(Object unused) { return null; }
+}

--- a/src/main/java/io/github/nokasegu/post_here/follow/dto/FollowingStatusResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/dto/FollowingStatusResponseDto.java
@@ -1,0 +1,27 @@
+package io.github.nokasegu.post_here.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/** 배치 상태 응답 */
+/** key: 사용자 id, value: 내가 팔로우 중인지 */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FollowingStatusResponseDto {
+
+    private Map<Long, Boolean> status;
+
+    public static FollowingStatusResponseDto from(Map<Long, Boolean> status) {
+        return FollowingStatusResponseDto.builder().status(status).build();
+    }
+
+    public static Object convertToEntity(FollowingStatusResponseDto d) { return null; }
+    public static FollowingStatusResponseDto convertToDto(Object unused) { return null; }
+}
+

--- a/src/main/java/io/github/nokasegu/post_here/follow/dto/UserBriefResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/dto/UserBriefResponseDto.java
@@ -1,0 +1,29 @@
+package io.github.nokasegu.post_here.follow.dto;
+
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBriefResponseDto {
+
+    private Long id;
+    private String nickname;
+    private String profilePhotoUrl;
+
+    public static UserBriefResponseDto convertToDto(UserInfoEntity e) {
+        return UserBriefResponseDto.builder()
+                .id(e.getId())
+                .nickname(e.getNickname())
+                .profilePhotoUrl(e.getProfilePhotoUrl())
+                .build();
+    }
+
+    public static UserInfoEntity convertToEntity(UserBriefResponseDto d) { return null; }
+}
+

--- a/src/main/java/io/github/nokasegu/post_here/follow/repository/FollowingRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/repository/FollowingRepository.java
@@ -1,9 +1,40 @@
 package io.github.nokasegu.post_here.follow.repository;
 
 import io.github.nokasegu.post_here.follow.domain.FollowingEntity;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FollowingRepository extends JpaRepository<FollowingEntity, Long> {
+
+    // 나를 팔로우하는 유저(팔로워 목록)
+    @Query("select f.follower " +
+            "from FollowingEntity f " +
+            "where f.followed.id = :meId " +
+            "order by f.follower.nickname asc, f.follower.id asc")
+    Page<UserInfoEntity> findFollowersByMeId(@Param("meId") Long meId, Pageable pageable);
+
+    // 내가 팔로우하는 유저(팔로잉 목록)
+    @Query("select f.followed " +
+            "from FollowingEntity f " +
+            "where f.follower.id = :meId " +
+            "order by f.followed.nickname asc, f.followed.id asc")
+    Page<UserInfoEntity> findFollowingsByMeId(@Param("meId") Long meId, Pageable pageable);
+
+    // 팔로우 여부/언팔에 사용
+    boolean existsByFollowerAndFollowed(UserInfoEntity follower, UserInfoEntity followed);
+    void deleteByFollowerAndFollowed(UserInfoEntity follower, UserInfoEntity followed);
+
+    // 배치 상태 API용: targetIds 중 내가 팔로잉한 id 목록
+    @Query("select f.followed.id " +
+            "from FollowingEntity f " +
+            "where f.follower.id = :meId and f.followed.id in :targetIds")
+    List<Long> findFollowedIdsByMeIn(@Param("meId") Long meId, @Param("targetIds") List<Long> targetIds);
 }

--- a/src/main/java/io/github/nokasegu/post_here/follow/service/FollowingService.java
+++ b/src/main/java/io/github/nokasegu/post_here/follow/service/FollowingService.java
@@ -1,12 +1,40 @@
 package io.github.nokasegu.post_here.follow.service;
 
 import io.github.nokasegu.post_here.follow.repository.FollowingRepository;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;             // ✅
+import org.springframework.data.domain.Pageable;        // ✅
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // ✅
+
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class FollowingService {
 
     private final FollowingRepository followingRepository;
+
+    // imports에 Pageable, Page, Transactional 추가
+    @Transactional(readOnly = true)
+    public Page<UserInfoEntity> getFollowers(Long meId, Pageable pageable) {
+        return followingRepository.findFollowersByMeId(meId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserInfoEntity> getFollowings(Long meId, Pageable pageable) {
+        return followingRepository.findFollowingsByMeId(meId, pageable);
+    }
+    @Transactional(readOnly = true)
+    public Map<Long, Boolean> getFollowingStatus(Long meId, List<Long> targetIds) {
+        if (targetIds == null || targetIds.isEmpty()) return Map.of();
+        List<Long> followedIds = followingRepository.findFollowedIdsByMeIn(meId, targetIds);
+        Set<Long> set = new HashSet<>(followedIds);
+        Map<Long, Boolean> res = new LinkedHashMap<>();
+        for (Long id : targetIds) res.put(id, set.contains(id));
+        return res;
+    }
+
+
 }

--- a/src/main/resources/templates/follow/friends.html
+++ b/src/main/resources/templates/follow/friends.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Friends</title>
+    <meta content="width=device-width, initial-scale=1" name="viewport"/>
+    <style>
+        :root {
+            --border: #e5e7eb;
+            --muted: #6b7280;
+            --bg: #fff;
+            --hover: #f9fafb;
+            --active: #111827;
+            --tab: #f3f4f6;
+            --radius: 14px;
+        }
+
+        * {
+            box-sizing: border-box
+        }
+
+        body {
+            font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial;
+            margin: 20px;
+            color: #111827;
+        }
+
+        h1 {
+            margin: 0 0 16px;
+            font-size: 28px;
+        }
+
+        .tabs {
+            display: flex;
+            gap: 8px;
+            margin: 14px 0;
+        }
+
+        .tab {
+            padding: 8px 12px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: var(--tab);
+            cursor: pointer;
+            font-weight: 600;
+            color: #111827;
+        }
+
+        .tab.active {
+            background: #111827;
+            color: #fff;
+            border-color: #111827;
+        }
+
+        .panel {
+            display: none;
+        }
+
+        .panel.active {
+            display: block;
+        }
+
+        .list {
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            overflow: hidden;
+            background: #fff;
+        }
+
+        .row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 14px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .row:last-child {
+            border-bottom: none;
+        }
+
+        .row:hover {
+            background: var(--hover);
+        }
+
+        .avatar {
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            object-fit: cover;
+            background: #f2f2f2;
+            flex: 0 0 44px;
+            cursor: pointer;
+        }
+
+        .meta {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+        }
+
+        .name {
+            font-weight: 600;
+            line-height: 1.2;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .spacer {
+            flex: 1;
+        }
+
+        .icon-btn {
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            padding: 6px;
+            border-radius: 10px;
+        }
+
+        .icon-btn:hover {
+            background: #f3f4f6;
+        }
+
+        .icon {
+            width: 22px;
+            height: 22px;
+            display: block;
+        }
+
+        .pager {
+            display: flex;
+            gap: 8px;
+            margin-top: 14px;
+            align-items: center;
+        }
+
+        .pager button {
+            padding: 8px 12px;
+            border: 1px solid var(--border);
+            background: #fff;
+            border-radius: 10px;
+            cursor: pointer;
+        }
+
+        .pager button:disabled {
+            opacity: .5;
+            cursor: default;
+        }
+
+        .empty {
+            padding: 24px;
+            text-align: center;
+            color: #6b7280;
+            border: 1px dashed var(--border);
+            border-radius: 12px;
+        }
+
+        .searchbar {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+
+        .searchbar input {
+            flex: 1;
+            height: 36px;
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+        }
+
+        .searchbar button {
+            height: 36px;
+            padding: 0 12px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            background: #fff;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+<h1>Friends</h1>
+
+<!-- 탭 -->
+<div class="tabs">
+    <button class="tab active" data-tab="followers">Follower</button>
+    <button class="tab" data-tab="followings">Following</button>
+    <button class="tab" data-tab="search">Search</button>
+</div>
+
+<!-- Followers -->
+<section class="panel active" id="panel-followers">
+    <div aria-live="polite" class="list" id="list-followers"></div>
+    <div class="pager">
+        <button id="prev-followers">이전</button>
+        <span id="page-followers"></span>
+        <button id="next-followers">다음</button>
+    </div>
+</section>
+
+<!-- Followings -->
+<section class="panel" id="panel-followings">
+    <div aria-live="polite" class="list" id="list-followings"></div>
+    <div class="pager">
+        <button id="prev-followings">이전</button>
+        <span id="page-followings"></span>
+        <button id="next-followings">다음</button>
+    </div>
+</section>
+
+<!-- Search (임시: 클라이언트 필터, 후에 서버 검색 API로 교체) -->
+<section class="panel" id="panel-search">
+    <div class="searchbar">
+        <input id="searchInput" placeholder="닉네임으로 검색" type="text"/>
+        <button id="searchBtn">검색</button>
+    </div>
+    <div aria-live="polite" class="list" id="list-search"></div>
+    <div class="pager">
+        <button id="prev-search">이전</button>
+        <span id="page-search"></span>
+        <button id="next-search">다음</button>
+    </div>
+</section>
+
+<script>
+    // ===== (옵션) 로그인 없이 테스트하려면 내 PK를 적어 X-USER-ID로 보냄 =====
+    const DEV_USER_ID = null; // 예: 1 로 바꾸면 비로그인 테스트 가능
+
+    // ===== 공통 DOM =====
+    const tabs = document.querySelectorAll('.tab');
+    const panels = {
+        followers: document.getElementById('panel-followers'),
+        followings: document.getElementById('panel-followings'),
+        search: document.getElementById('panel-search')
+    };
+    const listFollowers = document.getElementById('list-followers');
+    const listFollowings = document.getElementById('list-followings');
+    const listSearch = document.getElementById('list-search');
+    const pageFollowersEl = document.getElementById('page-followers');
+    const pageFollowingsEl = document.getElementById('page-followings');
+    const pageSearchEl = document.getElementById('page-search');
+
+    document.getElementById('prev-followers').addEventListener('click', () => {
+        if (state.page.followers > 0) {
+            state.page.followers--;
+            loadFollowers();
+        }
+    });
+    document.getElementById('next-followers').addEventListener('click', () => {
+        state.page.followers++;
+        loadFollowers();
+    });
+    document.getElementById('prev-followings').addEventListener('click', () => {
+        if (state.page.followings > 0) {
+            state.page.followings--;
+            loadFollowings();
+        }
+    });
+    document.getElementById('next-followings').addEventListener('click', () => {
+        state.page.followings++;
+        loadFollowings();
+    });
+    document.getElementById('prev-search').addEventListener('click', () => {
+        if (state.page.search > 0) {
+            state.page.search--;
+            loadSearch();
+        }
+    });
+    document.getElementById('next-search').addEventListener('click', () => {
+        state.page.search++;
+        loadSearch();
+    });
+    document.getElementById('searchBtn').addEventListener('click', () => {
+        state.page.search = 0;
+        loadSearch();
+    });
+
+    // ===== 상태 =====
+    let state = {
+        active: 'followers',
+        page: {followers: 0, followings: 0, search: 0},
+        followingSet: new Set(), // 내가 팔로우 중인 유저 id
+        searchPool: []           // 검색용 풀(초기엔 followers+followings 합집합)
+    };
+
+    // ===== 아이콘 =====
+    const personAddSvg = `
+      <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M15 8a4 4 0 1 0-8 0 4 4 0 0 0 8 0Z" stroke="currentColor" stroke-width="1.6"/>
+        <path d="M3.5 20a7 7 0 0 1 14 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+        <path d="M19 8v6M16 11h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+      </svg>`;
+    const personRemoveSvg = `
+      <svg class="icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <path d="M15 8a4 4 0 1 0-8 0 4 4 0 0 0 8 0Z" stroke="currentColor" stroke-width="1.6"/>
+        <path d="M3.5 20a7 7 0 0 1 14 0" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+        <path d="M16 11h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+      </svg>`;
+
+    // ===== 헬퍼 =====
+    function authHeaders(base = {}) {
+        if (DEV_USER_ID != null) return {...base, 'X-USER-ID': String(DEV_USER_ID)};
+        return base;
+    }
+
+    function applyPager(el, d, type) {
+        el.textContent = `페이지 ${d.number + 1} / ${d.totalPages} (총 ${d.totalElements}명)`;
+        document.getElementById(`prev-${type}`).disabled = d.first;
+        document.getElementById(`next-${type}`).disabled = d.last;
+    }
+
+    async function fetchStatus(ids) {
+        if (!ids || !ids.length) return {};
+        const res = await fetch('/api/friends/status', {
+            method: 'POST',
+            headers: authHeaders({'Content-Type': 'application/json', 'Accept': 'application/json'}),
+            body: JSON.stringify({ids})
+        });
+        if (!res.ok) return {};
+        const data = await res.json();
+        return data?.status || {};
+    }
+
+    // 한 줄 렌더 (mode: 'followers' | 'followings' | 'search')
+    function rowEl(user, mode, statusMap) {
+        const row = document.createElement('div');
+        row.className = 'row';
+
+        const img = document.createElement('img');
+        img.className = 'avatar';
+        img.src = user.profilePhotoUrl || `https://picsum.photos/seed/${user.id}/100/100`;
+        img.alt = '';
+        img.onclick = () => {
+            window.location.href = `/profile/${user.id}`
+        };
+        img.onerror = () => img.style.visibility = 'hidden';
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        const name = document.createElement('div');
+        name.className = 'name';
+        name.textContent = user.nickname || '(이름없음)';
+        meta.appendChild(name);
+
+        const spacer = document.createElement('div');
+        spacer.className = 'spacer';
+        let btn = null;
+
+        if (mode === 'followers' || mode === 'search') {
+            const already = statusMap ? !!statusMap[user.id] : state.followingSet.has(user.id);
+            if (!already) {
+                btn = document.createElement('button');
+                btn.className = 'icon-btn';
+                btn.title = '친구 추가';
+                btn.innerHTML = personAddSvg;
+                btn.addEventListener('click', () => {
+                    // TODO: follow API 연결
+                    btn.remove();
+                    state.followingSet.add(user.id);
+                });
+            }
+        } else if (mode === 'followings') {
+            btn = document.createElement('button');
+            btn.className = 'icon-btn';
+            btn.title = '친구 삭제';
+            btn.innerHTML = personRemoveSvg;
+            btn.addEventListener('click', () => {
+                // TODO: unfollow API 연결
+                btn.remove();
+                state.followingSet.delete(user.id);
+            });
+        }
+
+        row.appendChild(img);
+        row.appendChild(meta);
+        row.appendChild(spacer);
+        if (btn) row.appendChild(btn);
+        return row;
+    }
+
+
+    function renderList(container, pageData, mode, statusMap) {
+        const d = pageData;
+        if (!d || !d.content || d.content.length === 0) {
+            container.innerHTML = '<div class="empty">결과가 없습니다.</div>';
+            return;
+        }
+        container.innerHTML = '';
+        for (const u of d.content) container.appendChild(rowEl(u, mode, statusMap));
+    }
+
+    // ===== 탭 로더 =====
+    async function loadFollowers() {
+        listFollowers.innerHTML = '<div class="empty">로딩 중...</div>';
+        const res = await fetch(`/api/friends/followers?page=${state.page.followers}&size=20`, {headers: authHeaders({'Accept': 'application/json'})});
+        if (!res.ok) return listFollowers.innerHTML = `<div class="empty" style="color:#dc2626;">HTTP ${res.status}</div>`;
+        const d = await res.json();
+        const ids = (d.content || []).map(u => u.id);
+        const status = await fetchStatus(ids);
+        renderList(listFollowers, d, 'followers', status);
+        applyPager(pageFollowersEl, d, 'followers');
+    }
+
+    async function loadFollowings() {
+        listFollowings.innerHTML = '<div class="empty">로딩 중...</div>';
+        const res = await fetch(`/api/friends/followings?page=${state.page.followings}&size=20`, {headers: authHeaders({'Accept': 'application/json'})});
+        if (!res.ok) return listFollowings.innerHTML = `<div class="empty" style="color:#dc2626;">HTTP ${res.status}</div>`;
+        const d = await res.json();
+        if (state.page.followings === 0) state.followingSet = new Set((d.content || []).map(u => u.id));
+        renderList(listFollowings, d, 'followings');
+        applyPager(pageFollowingsEl, d, 'followings');
+    }
+
+    async function loadSearch() {
+        const q = (document.getElementById('searchInput').value || '').trim().toLowerCase();
+        const page = state.page.search, size = 20;
+
+        if (!state.searchPool.length) {
+            const [fRes, gRes] = await Promise.all([
+                fetch('/api/friends/followers?page=0&size=1000', {headers: authHeaders({'Accept': 'application/json'})}),
+                fetch('/api/friends/followings?page=0&size=1000', {headers: authHeaders({'Accept': 'application/json'})})
+            ]);
+            if (fRes.ok && gRes.ok) {
+                const [f, g] = await Promise.all([fRes.json(), gRes.json()]);
+                const map = new Map();
+                (f.content || []).forEach(u => map.set(u.id, u));
+                (g.content || []).forEach(u => map.set(u.id, u));
+                state.searchPool = Array.from(map.values());
+                state.followingSet = new Set((g.content || []).map(u => u.id));
+            }
+        }
+
+        let all = state.searchPool;
+        if (q) all = all.filter(u => (u.nickname || '').toLowerCase().includes(q));
+        const total = all.length, totalPages = Math.max(1, Math.ceil(total / size));
+        const slice = all.slice(page * size, page * size + size);
+
+        const ids = slice.map(u => u.id);
+        const status = await fetchStatus(ids);
+
+        const d = {
+            content: slice,
+            number: page,
+            size,
+            totalElements: total,
+            totalPages,
+            first: page <= 0,
+            last: (page + 1) >= totalPages
+        };
+        renderList(listSearch, d, 'search', status);
+        applyPager(pageSearchEl, d, 'search');
+    }
+
+    // 탭 전환
+    tabs.forEach(t => t.addEventListener('click', () => {
+        const tab = t.dataset.tab;
+        if (state.active === tab) return;
+        state.active = tab;
+        tabs.forEach(x => x.classList.toggle('active', x.dataset.tab === tab));
+        Object.entries(panels).forEach(([k, el]) => el.classList.toggle('active', k === tab));
+        if (tab === 'followers') loadFollowers();
+        else if (tab === 'followings') loadFollowings();
+        else loadSearch();
+    }));
+
+    // 초기 로딩: followers & followings 병렬 호출 (번들 API 불필요)
+    (async function init() {
+        listFollowers.innerHTML = listFollowings.innerHTML = '<div class="empty">로딩 중...</div>';
+        const [fRes, gRes] = await Promise.all([
+            fetch('/api/friends/followers?page=0&size=20', {headers: authHeaders({'Accept': 'application/json'})}),
+            fetch('/api/friends/followings?page=0&size=20', {headers: authHeaders({'Accept': 'application/json'})})
+        ]);
+        if (!fRes.ok || !gRes.ok) {
+            const msg = `초기 로딩 실패: followers=${fRes.status}, followings=${gRes.status}`;
+            listFollowers.innerHTML = listFollowings.innerHTML = `<div class="empty" style="color:#dc2626;">${msg}</div>`;
+            return;
+        }
+        const [followers, followings] = await Promise.all([fRes.json(), gRes.json()]);
+        state.followingSet = new Set((followings.content || []).map(u => u.id));
+
+        const ids = (followers.content || []).map(u => u.id);
+        const status = await fetchStatus(ids);
+
+        renderList(listFollowers, followers, 'followers', status);
+        applyPager(pageFollowersEl, followers, 'followers');
+
+        renderList(listFollowings, followings, 'followings');
+        applyPager(pageFollowingsEl, followings, 'followings');
+
+        const map = new Map();
+        (followers.content || []).forEach(u => map.set(u.id, u));
+        (followings.content || []).forEach(u => map.set(u.id, u));
+        state.searchPool = Array.from(map.values());
+    })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
백엔드
[Controller]
- FollowingApiController : 팔로워/팔로잉 조회 및 상태 조회 API · [GET] /api/friends/followers · [GET] /api/friends/followings · [POST] /api/friends/status
- FollowingController : 팔로워/팔로잉 관련 요청 처리(컨트롤러 추가)

[Service]
- FollowingService.getFollowers(), getFollowings(), getFollowingStatus()

[Repository]
- FollowingRepository : 팔로워/팔로잉 JPQL 조회 메소드 작성

[Entity]
- FollowingEntity : 팔로우 관계 Entity

[DTO]
- UserBriefResponseDto : id, nickname, profilePhotoUrl
- FollowingStatusRequestDto : 팔로잉 상태 요청 DTO
- FollowingStatusResponseDto : 팔로잉 상태 응답 DTO

프론트엔드
- friends.html : 팔로워/팔로잉/검색 탭 UI 추가
- JS : fetch API로 비동기 호출 및 UI 렌더링
- 프로필 사진 클릭 → /profile/{userId} 이동
- 팔로워/팔로잉 상태에 따라 친구 추가/삭제 버튼 표시 및 클릭 시 UI 즉시 반영 (※ DB상의 실제 following 상태 변경은 추후 팔로잉/언팔로잉 기능 구현 시 반영 예정)
- 검색(Search) 탭 페이지 골격만 구현 (검색 로직 추후 구현 예정)

Refs #4