### PR TITLE
[refactor] : 포럼 이미지 관련 로직 분리 및 DTO 개선

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
@@ -6,11 +6,10 @@ import io.github.nokasegu.post_here.forum.dto.ForumCreateRequestDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateResponseDto;
 import io.github.nokasegu.post_here.forum.service.ForumService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.io.IOException;
@@ -28,12 +27,11 @@ public class ForumController {
     }
 
     @ResponseBody
-    @PostMapping(value = "/forum", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/forum")
     public WrapperDTO<ForumCreateResponseDto> createForum(
-            @ModelAttribute ForumCreateRequestDto requestDto,
-            Principal principal) throws IOException { // Principal 객체를 파라미터로 받습니다.
+            @RequestBody ForumCreateRequestDto requestDto, // Changed from @ModelAttribute
+            Principal principal) throws IOException {
 
-        // Principal 객체에서 이메일을 가져와 DTO에 설정합니다.
         String userEmail = principal.getName();
         requestDto.setUserEmail(userEmail);
 

--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
@@ -1,12 +1,44 @@
 package io.github.nokasegu.post_here.forum.controller;
 
+import io.github.nokasegu.post_here.common.dto.WrapperDTO;
+import io.github.nokasegu.post_here.common.exception.Code;
 import io.github.nokasegu.post_here.forum.service.ForumImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
 public class ForumImageController {
 
     private final ForumImageService forumImageService;
+
+    @ResponseBody
+    @PostMapping(value = "/images/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public WrapperDTO<List<String>> uploadImages(@RequestPart("images") List<MultipartFile> images) throws IOException {
+
+        List<String> imageUrls = images.stream()
+                .map(image -> {
+                    try {
+                        return forumImageService.uploadImage(image, "forum-images");
+                    } catch (IOException e) {
+                        throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);
+                    }
+                })
+                .collect(Collectors.toList());
+
+        return WrapperDTO.<List<String>>builder()
+                .status(Code.OK.getCode())
+                .message(Code.OK.getValue())
+                .data(imageUrls)
+                .build();
+    }
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumCreateRequestDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumCreateRequestDto.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -20,7 +19,7 @@ public class ForumCreateRequestDto {
 
     private Long location;
 
-    private List<MultipartFile> images;
+    private List<String> imageUrls;
 
     private String spotifyTrackId;
 

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumImageService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumImageService.java
@@ -1,14 +1,41 @@
 package io.github.nokasegu.post_here.forum.service;
 
+import io.github.nokasegu.post_here.common.util.S3UploaderService;
+import io.github.nokasegu.post_here.forum.domain.ForumEntity;
+import io.github.nokasegu.post_here.forum.domain.ForumImageEntity;
 import io.github.nokasegu.post_here.forum.repository.ForumImageRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ForumImageService {
 
     private final ForumImageRepository forumImageRepository;
+    private final S3UploaderService s3UploaderService;
 
-    
+    // 포럼 게시글에 연결된 이미지 URL 목록을 DB에 저장합니다.
+    @Transactional
+    public void saveImages(ForumEntity forum, List<String> imageUrls) {
+        if (imageUrls != null && !imageUrls.isEmpty()) {
+            for (String imageUrl : imageUrls) {
+                ForumImageEntity forumImage = ForumImageEntity.builder()
+                        .forum(forum)
+                        .imgUrl(imageUrl)
+                        .build();
+                forumImageRepository.save(forumImage);
+            }
+        }
+    }
+
+    // S3 업로드를 전담하는 메서드를 추가합니다.
+    public String uploadImage(MultipartFile image, String dirName) throws IOException {
+        return s3UploaderService.upload(image, dirName);
+    }
+
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumService.java
@@ -1,13 +1,10 @@
 package io.github.nokasegu.post_here.forum.service;
 
-import io.github.nokasegu.post_here.common.util.S3UploaderService;
 import io.github.nokasegu.post_here.forum.domain.ForumAreaEntity;
 import io.github.nokasegu.post_here.forum.domain.ForumEntity;
-import io.github.nokasegu.post_here.forum.domain.ForumImageEntity;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateRequestDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateResponseDto;
 import io.github.nokasegu.post_here.forum.repository.ForumAreaRepository;
-import io.github.nokasegu.post_here.forum.repository.ForumImageRepository;
 import io.github.nokasegu.post_here.forum.repository.ForumRepository;
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
@@ -15,20 +12,17 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ForumService {
 
     private final ForumRepository forumRepository;
-    private final ForumImageRepository forumImageRepository;
     private final UserInfoRepository userInfoRepository;
-    private final S3UploaderService s3UploaderService;
     private final ForumAreaRepository forumAreaRepository;
+    private final ForumImageService forumImageService;
 
     @Transactional
     public ForumCreateResponseDto createForum(ForumCreateRequestDto requestDto) throws IOException {
@@ -50,21 +44,8 @@ public class ForumService {
                 .build();
         ForumEntity savedForum = forumRepository.save(forum);
 
-        // 3. 이미지 파일 목록을 S3에 업로드하고, 반환된 URL을 ForumImageEntity로 만들어 DB에 저장합니다.
-        List<MultipartFile> images = requestDto.getImages();
-        if (images != null && !images.isEmpty()) {
-            for (MultipartFile image : images) {
-                if (image != null && !image.isEmpty()) {
-                    String imageUrl = s3UploaderService.upload(image, "forum-images");
-
-                    ForumImageEntity forumImage = ForumImageEntity.builder()
-                            .forum(savedForum)
-                            .imgUrl(imageUrl)
-                            .build();
-                    forumImageRepository.save(forumImage);
-                }
-            }
-        }
+        // 3. 이미지 저장 로직을 ForumImageService에 위임합니다.
+        forumImageService.saveImages(savedForum, requestDto.getImageUrls());
 
         // 4. 컨트롤러에 전달할 응답 DTO를 생성하여 반환합니다.
         return new ForumCreateResponseDto(savedForum.getId());

--- a/src/main/resources/templates/forum/forum-write.html
+++ b/src/main/resources/templates/forum/forum-write.html
@@ -9,7 +9,8 @@
 <body>
 <form id="forum-form" style="display: contents;">
     <input id="writerId" name="writerId" type="hidden">
-    <input id="location" name="location" type="hidden" value="서울특별시 강남구 테헤란로">
+    <!-- 이미지 업로드를 위해 location에 임의의 value=1을 설정해두었다. -->
+    <input id="location" name="location" type="hidden" value="1">
     <input id="spotifyTrackId" name="spotifyTrackId" type="hidden">
 
     <input accept="image/*" id="images" multiple name="images" style="display: none;" type="file">


### PR DESCRIPTION
- 기존 ForumService와 ForumController에 혼재되어 있던 이미지 처리 로직을 별도의 클래스로 분리했습니다.
- ForumImageController와 ForumImageService를 구현하여 이미지 업로드 및 DB 저장의 책임을 전담하게 했습니다.
- ForumService는 S3 관련 의존성을 제거하고, 이미지 URL 목록을 DTO로 받아 ForumImageService에 위임하도록 수정했습니다.
- ForumCreateRequestDto를 이미지 파일(MultipartFile) 대신 이미지 URL(List<String>)을 받도록 변경했습니다.
 - forum-write.html: 다중 이미지 업로드에 필요한 폼 필드를 준비하고 스크립트를 연결했습니다.
 - forum-write.js: 이미지를 먼저 업로드하여 URL을 받은 후, 이 URL을 포함한 게시글 데이터를 서버에 전송하는 2단계 API 호출 로직을 구현했습니다.

Refs #33