### PR TITLE
[feat] : 포럼 지역 직접 선택 기능 구현

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
@@ -2,9 +2,12 @@ package io.github.nokasegu.post_here.forum.controller;
 
 import io.github.nokasegu.post_here.common.dto.WrapperDTO;
 import io.github.nokasegu.post_here.common.exception.Code;
+import io.github.nokasegu.post_here.forum.dto.ForumAreaRequestDto;
+import io.github.nokasegu.post_here.forum.dto.ForumAreaResponseDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateRequestDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateResponseDto;
 import io.github.nokasegu.post_here.forum.service.ForumService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -48,4 +52,51 @@ public class ForumController {
     public String forumMain() {
         return "forum/main";
     }
+
+    // 지역 검색 페이지로 이동
+    @GetMapping("/forum/area")
+    public String showForumAreaSearchPage() {
+        return "forum/forum-area-search";
+    }
+
+    // 선택된 지역을 세션에 저장하고, 리다이렉트 URL을 JSON으로 반환합니다.
+    @ResponseBody
+    @PostMapping("/forum/searchArea")
+    public WrapperDTO<String> setForumArea(
+            @RequestBody ForumAreaRequestDto requestDto,
+            HttpSession session) {
+        Long areaKey = forumService.setForumArea(requestDto, session);
+        String redirectUrl = "/forumMain?areaKey=" + areaKey;
+        return WrapperDTO.<String>builder()
+                .status(Code.OK.getCode())
+                .message("지역 설정이 성공적으로 변경되었습니다.")
+                .data(redirectUrl)
+                .build();
+    }
+
+    // 모든 지역 목록을 조회하는 API (검색 기능에 필요합니다)
+    @ResponseBody
+    @GetMapping("/forum/areas")
+    public WrapperDTO<List<ForumAreaResponseDto>> getAllAreas() {
+        List<ForumAreaResponseDto> areas = forumService.getAllAreas();
+        return WrapperDTO.<List<ForumAreaResponseDto>>builder()
+                .status(Code.OK.getCode())
+                .message("지역 목록을 성공적으로 불러왔습니다.")
+                .data(areas)
+                .build();
+    }
+
+    // 현재 위치 정보를 받아 해당 지역의 PK를 반환하는 API
+    @ResponseBody
+    @PostMapping("/location")
+    public WrapperDTO<Long> updateCurrentLocation(@RequestBody ForumAreaRequestDto requestDto) {
+        Long areaKey = forumService.getAreaKeyByAddress(requestDto.getLocation());
+        return WrapperDTO.<Long>builder()
+                .status(Code.OK.getCode())
+                .message(Code.OK.getValue())
+                .data(areaKey)
+                .build();
+    }
+
+
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumAreaRequestDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumAreaRequestDto.java
@@ -1,0 +1,12 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ForumAreaRequestDto {
+    private String location;
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumAreaResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumAreaResponseDto.java
@@ -1,0 +1,17 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import io.github.nokasegu.post_here.forum.domain.ForumAreaEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ForumAreaResponseDto {
+    private Long id;
+    private String address;
+
+    public ForumAreaResponseDto(ForumAreaEntity entity) {
+        this.id = entity.getId();
+        this.address = entity.getAddress();
+    }
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumAreaRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumAreaRepository.java
@@ -2,8 +2,13 @@ package io.github.nokasegu.post_here.forum.repository;
 
 import io.github.nokasegu.post_here.forum.domain.ForumAreaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Repository;
 
-@RestController
+import java.util.Optional;
+
+@Repository
 public interface ForumAreaRepository extends JpaRepository<ForumAreaEntity, Long> {
+
+    // 지역 주소(address)를 기준으로 ForumAreaEntity를 조회하는 메서드를 추가합니다.
+    Optional<ForumAreaEntity> findByAddress(String address);
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumService.java
@@ -2,6 +2,8 @@ package io.github.nokasegu.post_here.forum.service;
 
 import io.github.nokasegu.post_here.forum.domain.ForumAreaEntity;
 import io.github.nokasegu.post_here.forum.domain.ForumEntity;
+import io.github.nokasegu.post_here.forum.dto.ForumAreaRequestDto;
+import io.github.nokasegu.post_here.forum.dto.ForumAreaResponseDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateRequestDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCreateResponseDto;
 import io.github.nokasegu.post_here.forum.repository.ForumAreaRepository;
@@ -9,11 +11,14 @@ import io.github.nokasegu.post_here.forum.repository.ForumRepository;
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,18 +29,25 @@ public class ForumService {
     private final ForumAreaRepository forumAreaRepository;
     private final ForumImageService forumImageService;
 
+    /**
+     * 포럼 게시글을 생성하고 저장
+     *
+     * @param requestDto 게시글 생성 요청 DTO
+     * @return 생성된 게시글의 ID가 담긴 응답 DTO
+     */
+
     @Transactional
     public ForumCreateResponseDto createForum(ForumCreateRequestDto requestDto) throws IOException {
 
-        // 1. 서비스 내부에서 DTO에 담긴 이메일로 유저를 조회합니다.
-        String userEmail = requestDto.getUserEmail();
-        UserInfoEntity writer = userInfoRepository.findByEmail(userEmail)
+        // DTO에서 사용자 이메일을 가져와 유저를 조회
+        UserInfoEntity writer = userInfoRepository.findByEmail(requestDto.getUserEmail())
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
 
+        // DTO의 지역 ID로 ForumAreaEntity를 조회
         ForumAreaEntity area = forumAreaRepository.findById(requestDto.getLocation())
                 .orElseThrow(() -> new EntityNotFoundException("유효하지 않은 지역입니다"));
 
-        // 2. 텍스트, 위치, 음악 정보 등을 담은 ForumEntity를 생성하고 저장합니다.
+        // ForumEntity를 생성하고, 조회된 Entity를 location 필드에 연결
         ForumEntity forum = ForumEntity.builder()
                 .writer(writer)
                 .location(area)
@@ -44,10 +56,57 @@ public class ForumService {
                 .build();
         ForumEntity savedForum = forumRepository.save(forum);
 
-        // 3. 이미지 저장 로직을 ForumImageService에 위임합니다.
+        // 이미지 저장 로직을 ForumImageService에 위임
         forumImageService.saveImages(savedForum, requestDto.getImageUrls());
 
-        // 4. 컨트롤러에 전달할 응답 DTO를 생성하여 반환합니다.
+        // 컨트롤러에 전달할 응답 DTO를 생성하여 반환
         return new ForumCreateResponseDto(savedForum.getId());
     }
+
+    /**
+     * 사용자가 선택한 지역을 세션에 저장하고, 해당 지역의 ID를 반환하는 메서드
+     *
+     * @param requestDto 클라이언트로부터 받은 지역 정보 DTO
+     * @param session    현재 HTTP 세션
+     * @return 세션에 저장된 지역의 PK (ID)
+     */
+    public Long setForumArea(ForumAreaRequestDto requestDto, HttpSession session) {
+        String newLocationAddress = requestDto.getLocation();
+
+        ForumAreaEntity area = forumAreaRepository.findByAddress(newLocationAddress)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지역 정보입니다."));
+
+        // 세션에 지역 주소(address)를 저장
+        session.setAttribute("selectedForumAreaAddress", area.getAddress());
+
+        // 지역의 PK를 반환하여 컨트롤러가 리다이렉트 URL을 구성
+        return area.getId();
+    }
+
+    /**
+     * 주소 문자열을 사용하여 지역의 PK (ID)를 조회합니다.
+     *
+     * @param address 조회할 지역의 주소 문자열
+     * @return 해당 지역의 PK (ID)
+     */
+
+    public Long getAreaKeyByAddress(String address) {
+        ForumAreaEntity area = forumAreaRepository.findByAddress(address)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지역 정보입니다."));
+        return area.getId();
+    }
+
+    /**
+     * 모든 포럼 지역 목록을 조회합니다.
+     *
+     * @return 모든 지역 정보 DTO 리스트
+     */
+
+    public List<ForumAreaResponseDto> getAllAreas() {
+        return forumAreaRepository.findAll().stream()
+                .map(ForumAreaResponseDto::new)
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/resources/static/forumJs/forum-area-search.js
+++ b/src/main/resources/static/forumJs/forum-area-search.js
@@ -1,0 +1,102 @@
+// src/main/resources/static/forumJs/forum-area-search.js
+$(document).ready(function () {
+    const searchInput = $('#location-search');
+    const resultsList = $('#search-results');
+    let availableLocations = []; // 지역 목록을 저장할 빈 배열
+
+    // 1. 페이지 로드 시 백엔드에서 지역 목록을 가져오는 함수
+    function fetchAvailableLocations() {
+        $.ajax({
+            url: '/forum/areas',
+            type: 'GET',
+            dataType: 'json',
+            success: function (result) {
+                if (result.status === '000') {
+                    availableLocations = result.data; // 가져온 데이터를 배열에 저장
+                } else {
+                    console.error('지역 목록을 불러오는 데 실패했습니다:', result.message);
+                    alert('지역 목록을 불러오는 데 실패했습니다. 다시 시도해주세요.');
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                console.error('네트워크 오류:', textStatus, errorThrown);
+                alert('네트워크 오류로 지역 목록을 가져올 수 없습니다.');
+            }
+        });
+    }
+
+    // 2. 페이지 로드 시 함수 실행
+    fetchAvailableLocations();
+
+    // ----------------------------------------------------
+    // 한글 자모 검색을 위한 로직
+    // ----------------------------------------------------
+    const CHO = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
+    const JUNG = ['ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ'];
+    const JONG = ['', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
+
+    function getJamo(char) {
+        const code = char.charCodeAt(0);
+        const jamoCode = code - 0xAC00;
+
+        if (jamoCode >= 0 && jamoCode <= 11172) {
+            const choIndex = Math.floor(jamoCode / 588);
+            const jungIndex = Math.floor((jamoCode % 588) / 28);
+            const jongIndex = jamoCode % 28;
+
+            return CHO[choIndex] + JUNG[jungIndex] + JONG[jongIndex];
+        }
+        return char;
+    }
+
+    function isMatch(text, query) {
+        const textJamo = text.split('').map(getJamo).join('').toLowerCase();
+        const queryJamo = query.split('').map(getJamo).join('').toLowerCase();
+
+        return textJamo.includes(queryJamo);
+    }
+
+    // 3. 입력창에 타이핑할 때마다 검색 결과를 업데이트
+    searchInput.on('input', function () {
+        const query = searchInput.val().trim();
+        resultsList.empty();
+
+        if (query.length > 0) {
+            const filteredLocations = availableLocations.filter(area =>
+                // isMatch 함수를 사용해 한글 자모 검색을 수행
+                isMatch(area.address, query)
+            );
+
+            let str = '';
+            filteredLocations.forEach(area => {
+                str += `<li data-location-id="${area.id}">${area.address}</li>`;
+            });
+            resultsList.html(str);
+        }
+    });
+
+    // 4. 검색 결과 항목을 클릭했을 때의 동작
+    resultsList.on('click', 'li', function () {
+        const selectedLocation = $(this).text();
+        const locationId = $(this).data('location-id');
+
+        $.ajax({
+            url: '/forum/searchArea',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({location: selectedLocation}),
+            success: function (result) {
+                if (result.status === '000') {
+                    alert('지역이 성공적으로 설정되었습니다: ' + selectedLocation);
+                    window.location.href = result.data;
+                } else {
+                    alert('작성 실패: ' + (result.message || '서버 오류'));
+                }
+            },
+            error: function (jqXHR, textStatus, errorThrown) {
+                console.error('API 요청 오류:', textStatus, errorThrown);
+                alert('네트워크 오류가 발생했습니다.');
+            }
+        });
+    });
+});

--- a/src/main/resources/templates/forum/forum-area-search.html
+++ b/src/main/resources/templates/forum/forum-area-search.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forum Area Search</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="/forumJs/forum-area-search.js"></script>
+    <link rel="manifest" th:href="@{/pwa/manifest.json}">
+</head>
+<body>
+<div class="search-container">
+    <h1>지역 검색</h1>
+    <div class="search-bar">
+        <input class="search-input" id="location-search" placeholder="지역을 검색하세요..." type="text">
+    </div>
+    <ul class="search-results" id="search-results">
+    </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- 포럼 지역 정보를 관리하는 ForumAreaEntity, ForumAreaRepository를 구현했습니다.
- POST /forum/searchArea, POST /location API를 구현하여 사용자가 위치를 선택하고 저장할 수 있도록 했습니다.
- ForumService에서 지역명으로 PK를 조회하고, ForumController에서 이를 활용해 리다이렉트 URL을 구성합니다.
- Session 대신 localStorage를 사용하는 새로운 아키텍처를 적용했습니다.

- forum-area-search.html과 forum-area-search.js를 구현하여 지역 검색 UI와 실시간 검색 기능을 완성했습니다.
- 한글 초성 검색 로직을 적용하여 검색 편의성을 높였습니다.
- 선택한 지역 정보를 백엔드에 전송하고 리다이렉트 URL을 받아 메인 페이지로 이동하는 로직을 구현했습니다.

Refs #35