### PR TITLE
[feat]: 포럼 좋아요 기능 구현

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumLikeController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumLikeController.java
@@ -1,12 +1,47 @@
 package io.github.nokasegu.post_here.forum.controller;
 
+import io.github.nokasegu.post_here.common.dto.WrapperDTO;
+import io.github.nokasegu.post_here.common.exception.Code;
+import io.github.nokasegu.post_here.common.security.CustomUserDetails;
+import io.github.nokasegu.post_here.forum.dto.ForumLikeResponseDto;
 import io.github.nokasegu.post_here.forum.service.ForumLikeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequiredArgsConstructor
 public class ForumLikeController {
 
     private final ForumLikeService forumLikeService;
+
+    /**
+     * 좋아요를 누르거나 취소하는 API
+     *
+     * @param forumId 좋아요를 토글할 게시글 ID
+     * @param liker   현재 인증된 사용자 정보 (CustomUserDetails)
+     * @return 변경된 좋아요 상태를 포함한 응답
+     */
+    @ResponseBody
+    @PostMapping("/forum/like/{forumId}")
+    public WrapperDTO<ForumLikeResponseDto> toggleLike(
+            @PathVariable("forumId") Long forumId,
+            // ✅ @AuthenticationPrincipal을 CustomUserDetails로 직접 받습니다.
+            @AuthenticationPrincipal CustomUserDetails liker) {
+
+        // ✅ CustomUserDetails 객체에서 사용자 ID를 직접 가져옵니다.
+        Long likerId = liker.getUserInfo().getId();
+
+        // ForumLikeService에 좋아요 토글 로직 위임
+        ForumLikeResponseDto responseDto = forumLikeService.toggleLike(forumId, likerId);
+
+        return WrapperDTO.<ForumLikeResponseDto>builder()
+                .status(Code.OK.getCode())
+                .message(Code.OK.getValue())
+                .data(responseDto)
+                .build();
+    }
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumLikeResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumLikeResponseDto.java
@@ -1,0 +1,16 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ForumLikeResponseDto {
+
+    private int totalLikes;
+    private List<String> recentLikerPhotos;
+    private boolean isLiked; // 현재 사용자의 좋아요 여부
+
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
@@ -24,10 +24,18 @@ public class ForumPostListResponseDto {
 
     private LocalDateTime createdAt;
 
+    // 좋아요 관련 필드
+    private int totalLikes;
+    private boolean isLiked;
+    private List<String> recentLikerPhotos;
+
     public ForumPostListResponseDto(
             ForumEntity forumEntity,
             int totalComments,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            int totalLikes,
+            boolean isLiked,
+            List<String> recentLikerPhotos
     ) {
         this.id = forumEntity.getId();
         // ForumAreaEntity 객체에서 address 필드를 가져와 String으로 설정
@@ -41,5 +49,8 @@ public class ForumPostListResponseDto {
         this.writerProfilePhotoUrl = forumEntity.getWriter().getProfilePhotoUrl();
         this.totalComments = totalComments;
         this.createdAt = forumEntity.getCreatedAt();
+        this.totalLikes = totalLikes;
+        this.isLiked = isLiked;
+        this.recentLikerPhotos = recentLikerPhotos;
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumLikeRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumLikeRepository.java
@@ -4,6 +4,19 @@ import io.github.nokasegu.post_here.forum.domain.ForumLikeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface ForumLikeRepository extends JpaRepository<ForumLikeEntity, Long> {
+
+    // 특정 사용자가 특정 게시글에 좋아요를 눌렀는지 확인
+    Optional<ForumLikeEntity> findByForumIdAndLikerId(Long forumId, Long likerId);
+
+    // 특정 게시글의 좋아요 총 개수 조회
+    int countByForumId(Long forumId);
+
+    // 특정 게시글에 좋아요를 누른 최근 3명의 사용자 정보(프로필 사진 URL) 조회
+    List<ForumLikeEntity> findTop3ByForumIdOrderByCreatedAtDesc(Long forumId);
+    
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumLikeService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumLikeService.java
@@ -1,12 +1,101 @@
 package io.github.nokasegu.post_here.forum.service;
 
+import io.github.nokasegu.post_here.forum.domain.ForumEntity;
+import io.github.nokasegu.post_here.forum.domain.ForumLikeEntity;
+import io.github.nokasegu.post_here.forum.dto.ForumLikeResponseDto;
 import io.github.nokasegu.post_here.forum.repository.ForumLikeRepository;
+import io.github.nokasegu.post_here.forum.repository.ForumRepository;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ForumLikeService {
 
+    // 좋아요 데이터 접근을 위한 리포지토리
     private final ForumLikeRepository forumLikeRepository;
+    // 포럼 게시글 정보 접근을 위한 리포지토리
+    private final ForumRepository forumRepository;
+    // 사용자 정보 접근을 위한 리포지토리
+    private final UserInfoRepository userInfoRepository;
+
+    /**
+     * 포럼 게시글의 좋아요 상태를 토글합니다.
+     * 이미 좋아요를 눌렀다면 좋아요를 취소하고, 아니면 좋아요를 추가합니다.
+     *
+     * @param forumId 좋아요를 누를 게시글의 ID
+     * @param likerId 좋아요를 누른 사용자의 ID
+     * @return 변경된 좋아요 상태를 담은 DTO
+     */
+    public ForumLikeResponseDto toggleLike(Long forumId, Long likerId) {
+        // 게시글 존재 여부 확인
+        ForumEntity forum = forumRepository.findById(forumId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 게시글을 찾을 수 없습니다."));
+
+        // 사용자 존재 여부 확인
+        UserInfoEntity liker = userInfoRepository.findById(likerId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        // 기존에 좋아요를 눌렀는지 확인
+        Optional<ForumLikeEntity> existingLike = forumLikeRepository.findByForumIdAndLikerId(forumId, likerId);
+
+        boolean isLiked;
+        if (existingLike.isPresent()) {
+            // 좋아요가 존재하면 삭제
+            forumLikeRepository.delete(existingLike.get());
+            isLiked = false;
+        } else {
+            // 좋아요가 없으면 새로 생성하여 저장
+            ForumLikeEntity newLike = ForumLikeEntity.builder()
+                    .forum(forum)
+                    .liker(liker)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            forumLikeRepository.save(newLike);
+            isLiked = true;
+        }
+
+        // DB에 다시 접근하지 않고, 변경된 상태를 기반으로 DTO를 만듭니다.
+        // 좋아요 총 개수는 DB에서 다시 조회 (가장 정확한 최신 상태)
+        int totalLikes = forumLikeRepository.countByForumId(forumId);
+        List<String> recentLikerPhotos = forumLikeRepository.findTop3ByForumIdOrderByCreatedAtDesc(forumId)
+                .stream()
+                .map(like -> like.getLiker().getProfilePhotoUrl())
+                .collect(Collectors.toList());
+
+        return new ForumLikeResponseDto(totalLikes, recentLikerPhotos, isLiked);
+    }
+
+    /**
+     * 특정 게시글의 좋아요 상태(총 개수, 최근 3명의 프로필 사진)를 조회합니다.
+     * 이 메서드는 좋아요 여부(isLiked)를 판단하지 않고,
+     * 게시글 자체의 좋아요 현황만 제공합니다.
+     *
+     * @param forumId 좋아요 상태를 조회할 게시글의 ID
+     * @return 좋아요 상태를 담은 DTO
+     */
+    public ForumLikeResponseDto getLikeStatus(Long forumId) {
+        // 특정 게시글의 좋아요 총 개수를 조회
+        int totalLikes = forumLikeRepository.countByForumId(forumId);
+
+        // 최근 좋아요를 누른 3명의 프로필 사진 URL 목록을 조회
+        List<String> recentLikerPhotos = forumLikeRepository.findTop3ByForumIdOrderByCreatedAtDesc(forumId)
+                .stream()
+                .map(like -> like.getLiker().getProfilePhotoUrl())
+                .collect(Collectors.toList());
+
+        // 좋아요 여부는 이 메서드의 역할이 아니므로 false로 고정하여 반환
+        return new ForumLikeResponseDto(totalLikes, recentLikerPhotos, false);
+    }
+
 }


### PR DESCRIPTION
## 구현 내용 요약
- 좋아요 API 구현
- 좋아요 상태에 따른 동적 UI 업데이트

---

## 관련 이슈
Closes #47 

---

## 작업 상세 내역
- ForumLikeController: 좋아요 API 엔드포인트 POST /forum/like/{forumId} 구현
- ForumLikeService: 좋아요 토글(추가/삭제), 총 좋아요 개수, 그리고 최근 좋아요 3명의 사용자 프로필 사진 조회 로직 구현
- ForumLikeRepository: 좋아요 상태 및 총 개수 조회를 위한 JPA Repository 메서드 추가
- ForumLikeResponseDto: 좋아요 총 개수, 좋아요 상태, 프로필 사진 URL 목록 필드 추가
- ForumPostListResponseDto: 게시물 목록 조회 시 좋아요 관련 데이터 반환을 위해 필드 수정
- main.js: 좋아요 버튼 클릭 시 API를 호출하고, 응답에 따라 좋아요 상태를 동적으로 업데이트하는 로직 구현

---

## from to
<feature/like> -> <develop>

---