### PR TITLE
Refactor/forum image creation

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
@@ -54,7 +54,73 @@ public class ForumController {
                 .data(responseData)
                 .build();
     }
-    
+
+    /**
+     * 게시글 수정 페이지로 이동
+     *
+     * @param forumId     수정할 게시글 ID
+     * @param userDetails 현재 사용자 정보 (권한 확인용)
+     * @param model       Thymeleaf 모델
+     * @return 수정 페이지 뷰
+     */
+    @GetMapping("/forum/{forumId}/edit")
+    public String editForumPage(
+            @PathVariable("forumId") Long forumId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            Model model) {
+
+        // 현재 사용자 ID를 서비스에 전달하여 게시글 정보와 권한을 함께 확인합니다.
+        ForumDetailResponseDto forumDetail = forumService.getForumDetail(forumId, userDetails.getUserInfo().getId());
+
+        // 모델에 게시글 정보를 추가
+        model.addAttribute("forum", forumDetail);
+
+        return "forum/forum-edit";
+    }
+
+
+    /**
+     * 게시글 수정 API
+     *
+     * @param forumId     수정할 게시글 ID
+     * @param requestDto  수정할 데이터와 삭제할 이미지 ID 목록
+     * @param userDetails 현재 사용자 정보
+     * @return 성공 메시지
+     */
+    @ResponseBody
+    @PostMapping("/forum/{forumId}")
+    public WrapperDTO<String> updateForum(
+            @PathVariable("forumId") Long forumId,
+            @RequestBody ForumUpdateRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        // 클라이언트에서 보낸 DTO를 서비스로 전달
+        forumService.updateForum(forumId, requestDto, userDetails.getUserInfo().getId());
+        return WrapperDTO.<String>builder()
+                .status(Code.OK.getCode())
+                .message("게시글이 성공적으로 수정되었습니다.")
+                .data("/forumMain")
+                .build();
+    }
+
+    /**
+     * 게시글 삭제 API
+     *
+     * @param forumId     삭제할 게시글 ID
+     * @param userDetails 현재 사용자 정보
+     * @return 성공 메시지
+     */
+    @ResponseBody
+    @DeleteMapping("/forum/{forumId}")
+    public WrapperDTO<String> deleteForum(
+            @PathVariable("forumId") Long forumId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        forumService.deleteForum(forumId, userDetails.getUserInfo().getId());
+        return WrapperDTO.<String>builder()
+                .status(Code.OK.getCode())
+                .message("게시글이 성공적으로 삭제되었습니다.")
+                .build();
+    }
+
     // 포럼 목록 열람 API
     @ResponseBody
     @GetMapping("/forum/area/{key}")

--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
@@ -42,12 +42,10 @@ public class ForumController {
     public WrapperDTO<ForumCreateResponseDto> createForum(
             @RequestBody ForumCreateRequestDto requestDto,
             Principal principal) throws IOException {
-
-        // 인증된 사용자의 이메일을 컨트롤러에서 직접 가져와 DTO에 설정
         String userEmail = principal.getName();
         requestDto.setUserEmail(userEmail);
 
-        // DTO를 서비스로 전달
+        // 이미지 ID 목록을 담은 DTO를 서비스로 전달
         ForumCreateResponseDto responseData = forumService.createForum(requestDto);
 
         return WrapperDTO.<ForumCreateResponseDto>builder()
@@ -56,7 +54,7 @@ public class ForumController {
                 .data(responseData)
                 .build();
     }
-
+    
     // 포럼 목록 열람 API
     @ResponseBody
     @GetMapping("/forum/area/{key}")

--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
@@ -23,12 +23,12 @@ public class ForumImageController {
 
     @ResponseBody
     @PostMapping(value = "/images/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public WrapperDTO<List<String>> uploadImages(@RequestPart("images") List<MultipartFile> images) throws IOException {
-
+    public WrapperDTO<List<String>> uploadImages(@RequestPart("images") List<MultipartFile> images) {
         List<String> imageUrls = images.stream()
                 .map(image -> {
                     try {
-                        return forumImageService.uploadImage(image, "forum-images");
+                        // ★★★ 변경: S3에 업로드만 하고 URL을 반환합니다. ★★★
+                        return forumImageService.uploadImage(image);
                     } catch (IOException e) {
                         throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);
                     }

--- a/src/main/java/io/github/nokasegu/post_here/forum/domain/ForumEntity.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/domain/ForumEntity.java
@@ -2,10 +2,7 @@ package io.github.nokasegu.post_here.forum.domain;
 
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,6 +15,7 @@ import java.util.List;
 @Entity
 @Table(name = "forum")
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumCreateRequestDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumCreateRequestDto.java
@@ -19,7 +19,7 @@ public class ForumCreateRequestDto {
     private Long location;
 
     private List<String> imageUrls;
-
+    
     private String spotifyTrackId;
 
     private String userEmail;

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumDetailResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumDetailResponseDto.java
@@ -1,0 +1,34 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import io.github.nokasegu.post_here.forum.domain.ForumEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ForumDetailResponseDto {
+
+    private Long id;
+    private String contentsText;
+    private String musicApiUrl;
+    private List<ForumImageResponseDto> images;
+    private Long locationId;
+    private boolean isAuthor;
+
+    public ForumDetailResponseDto(ForumEntity forumEntity, boolean isAuthor) {
+        this.id = forumEntity.getId();
+        this.contentsText = forumEntity.getContentsText();
+        this.musicApiUrl = forumEntity.getMusicApiUrl();
+        this.locationId = forumEntity.getLocation().getId();
+        this.images = forumEntity.getImages().stream()
+                .map(ForumImageResponseDto::new)
+                .collect(Collectors.toList());
+        this.isAuthor = isAuthor;
+    }
+
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumImageResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumImageResponseDto.java
@@ -1,0 +1,17 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import io.github.nokasegu.post_here.forum.domain.ForumImageEntity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ForumImageResponseDto {
+    private Long id;
+    private String imgUrl;
+
+    public ForumImageResponseDto(ForumImageEntity entity) {
+        this.id = entity.getId();
+        this.imgUrl = entity.getImgUrl();
+    }
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumImageUploadResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumImageUploadResponseDto.java
@@ -1,0 +1,13 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class ForumImageUploadResponseDto {
+    private Long imageId;
+    private String imageUrl;
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
@@ -21,6 +21,7 @@ public class ForumPostListResponseDto {
     private String musicApiUrl;
     private String writerProfilePhotoUrl;
     private int totalComments;
+    private boolean author;
 
     private LocalDateTime createdAt;
 
@@ -35,7 +36,8 @@ public class ForumPostListResponseDto {
             LocalDateTime createdAt,
             int totalLikes,
             boolean isLiked,
-            List<String> recentLikerPhotos
+            List<String> recentLikerPhotos,
+            boolean author
     ) {
         this.id = forumEntity.getId();
         // ForumAreaEntity 객체에서 address 필드를 가져와 String으로 설정
@@ -52,5 +54,6 @@ public class ForumPostListResponseDto {
         this.totalLikes = totalLikes;
         this.isLiked = isLiked;
         this.recentLikerPhotos = recentLikerPhotos;
+        this.author = author;
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumUpdateRequestDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package io.github.nokasegu.post_here.forum.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ForumUpdateRequestDto {
+    private String content;
+    private String musicApiUrl;
+    private List<Long> deletedImageIds; // 제할 이미지 ID 목록
+}

--- a/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumImageRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumImageRepository.java
@@ -1,9 +1,17 @@
 package io.github.nokasegu.post_here.forum.repository;
 
+import io.github.nokasegu.post_here.forum.domain.ForumEntity;
 import io.github.nokasegu.post_here.forum.domain.ForumImageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ForumImageRepository extends JpaRepository<ForumImageEntity, Long> {
+    // 특정 ForumEntity에 속한 모든 ForumImageEntity를 찾기
+    List<ForumImageEntity> findByForum(ForumEntity forum);
+
+    // 특정 Forum ID에 속한 모든 이미지를 찾는 메소드 추가
+    List<ForumImageEntity> findByForumId(Long forumId);
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumImageService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumImageService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +21,22 @@ public class ForumImageService {
     private final S3UploaderService s3UploaderService;
 
     /**
-     * 이미지를 S3에 업로드하고 URL을 반환합니다. (DB 저장 없음)
+     * 이미지 URL을 받아 DB에 저장하고, 포럼 게시글에 연결
+     *
+     * @param imageUrl DB에 저장할 이미지 URL
+     * @param forum    이미지와 연결할 포럼 엔티티
+     * @return DB에 저장된 ForumImageEntity
+     */
+    public ForumImageEntity saveImage(String imageUrl, ForumEntity forum) {
+        ForumImageEntity forumImage = ForumImageEntity.builder()
+                .imgUrl(imageUrl)
+                .forum(forum) // ForumEntity를 받아 바로 연결
+                .build();
+        return forumImageRepository.save(forumImage);
+    }
+
+    /**
+     * 이미지를 S3에 업로드하고 URL을 반환 (DB 저장 없음)
      *
      * @param image MultipartFile 객체
      * @return S3에 업로드된 이미지의 URL
@@ -31,17 +47,34 @@ public class ForumImageService {
     }
 
     /**
-     * 이미지 URL을 받아 DB에 저장하고, 포럼 게시글에 연결합니다.
+     * 포럼에 연결된 모든 이미지 엔티티를 DB와 S3에서 삭제
      *
-     * @param imageUrl DB에 저장할 이미지 URL
-     * @param forum    이미지와 연결할 포럼 엔티티
-     * @return DB에 저장된 ForumImageEntity
+     * @param forum 이미지를 삭제할 ForumEntity
      */
-    public ForumImageEntity saveImage(String imageUrl, ForumEntity forum) {
-        ForumImageEntity forumImage = ForumImageEntity.builder()
-                .imgUrl(imageUrl)
-                .forum(forum) // ★★★ 변경: ForumEntity를 받아 바로 연결합니다. ★★★
-                .build();
-        return forumImageRepository.save(forumImage);
+    public void deleteImages(ForumEntity forum) {
+        List<ForumImageEntity> images = forumImageRepository.findByForum(forum);
+        for (ForumImageEntity image : images) {
+            s3UploaderService.delete(image.getImgUrl());
+        }
+        forumImageRepository.deleteAll(images);
+    }
+
+    /**
+     * ID 목록에 해당하는 이미지들을 DB와 S3에서 삭제합니다.
+     *
+     * @param imageIds 삭제할 이미지 ID 목록
+     * @param userId   현재 사용자 ID (권한 확인용)
+     */
+    public void deleteImagesByIds(List<Long> imageIds, Long userId) {
+        List<ForumImageEntity> imagesToDelete = forumImageRepository.findAllById(imageIds);
+
+        for (ForumImageEntity image : imagesToDelete) {
+            if (!image.getForum().getWriter().getId().equals(userId)) {
+                throw new IllegalArgumentException("해당 이미지에 대한 삭제 권한이 없습니다.");
+            }
+            s3UploaderService.delete(image.getImgUrl());
+        }
+
+        forumImageRepository.deleteAll(imagesToDelete);
     }
 }

--- a/src/main/js/app.js
+++ b/src/main/js/app.js
@@ -26,7 +26,7 @@ import {initForumAreaSearch} from './pages/forum-area-search.js';
 import {initParkWrite} from './pages/park-write.js';
 import {initNotification} from './pages/notification.js';
 import {initFindOnMap} from "./pages/find-on-map";
-
+import {initForumEdit} from './pages/forum-edit'
 
 // --- 3. 초기 경로 설정 ---
 // 앱이 처음 로드되었을 때(경로가 '/') 시작 페이지로 이동시킵니다.
@@ -104,6 +104,9 @@ document.addEventListener('DOMContentLoaded', () => {
             break;
         case 'page-notifications':
             initNotification();
+            break;
+        case 'page-forum-edit':
+            initForumEdit();
             break;
         default:
             console.log('이 페이지에 해당하는 초기화 스크립트가 없습니다.');

--- a/src/main/js/pages/forum-edit.js
+++ b/src/main/js/pages/forum-edit.js
@@ -1,0 +1,73 @@
+export function initForumEdit() {
+    const forumId = $('#forum-id').val();
+    const forumForm = $('#edit-forum-form');
+    const contentTextarea = $('#forum-content');
+    const musicUrlInput = $('#music-url-input');
+
+    // 삭제된 이미지 ID를 담을 배열
+    const deletedImageIds = [];
+
+    // 뒤로가기 버튼 이벤트
+    $('#back-button').on('click', function () {
+        window.location.href = '/forumMain';
+    });
+
+    // 사진/음악 삭제 버튼 이벤트
+    $('.delete-media-button').on('click', function () {
+        const button = $(this);
+        const mediaType = button.data('type');
+
+        if (mediaType === 'image') {
+            const imageId = button.data('image-id');
+            if (imageId) {
+                // 서버에 요청을 보내지 않고 ID만 배열에 추가
+                deletedImageIds.push(imageId);
+                // UI에서만 해당 이미지 요소를 숨김
+                button.closest('.media-item').hide();
+                console.log(`이미지 ID ${imageId} 삭제 예정 (배열에 추가됨)`);
+            }
+        } else if (mediaType === 'music') {
+            button.closest('.music-item').remove();
+            musicUrlInput.val('');
+            console.log('음악 삭제');
+        }
+    });
+
+    // 폼 제출 (수정 완료) 이벤트
+    forumForm.on('submit', async function (e) {
+        e.preventDefault();
+
+        const updatedContents = contentTextarea.val().trim();
+        const updatedMusicUrl = musicUrlInput.val() || null;
+
+        const requestBody = {
+            content: updatedContents,
+            musicApiUrl: updatedMusicUrl,
+            deletedImageIds: deletedImageIds // ★★★ 변경: 삭제할 ID 목록을 직접 전송 ★★★
+        };
+
+        try {
+            const response = await fetch(`/forum/${forumId}`, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(requestBody)
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
+            }
+
+            const result = await response.json();
+            if (result.status === '000') {
+                alert('게시글이 성공적으로 수정되었습니다.');
+                window.location.href = result.data;
+            } else {
+                alert('게시글 수정에 실패했습니다: ' + result.message);
+            }
+        } catch (error) {
+            console.error('게시글 수정 오류:', error);
+            alert('게시글 수정 중 오류가 발생했습니다.');
+        }
+    });
+}

--- a/src/main/js/pages/forum-write.js
+++ b/src/main/js/pages/forum-write.js
@@ -6,26 +6,23 @@ export function initForumWrite() {
     const addImageButton = document.getElementById('add-image-btn');
     const imagePreviewContainer = document.getElementById('image-preview-container');
 
-    // '이미지 추가(🖼️)' 버튼 클릭 시, 숨겨진 파일 input을 클릭합니다.
+    // 사용자가 선택한 파일들을 저장할 배열
+    let selectedImageFiles = [];
+
+    // '이미지 추가' 버튼 클릭 시, 숨겨진 파일 input을 클릭합니다.
     addImageButton.addEventListener('click', () => {
         imageInput.click();
     });
 
-    // '음악 추가(🎵)' 버튼 클릭 시 동작 (지금은 알림창만 띄웁니다)
-    document.getElementById('add-music-btn').addEventListener('click', () => {
-        const trackId = prompt("연결할 Spotify 트랙 ID를 입력하세요:", "4uPiFjZpAfggB4aW2v2p4M");
-        if (trackId) {
-            document.getElementById('spotifyTrackId').value = trackId;
-            alert(`음악이 추가되었습니다: ${trackId}`);
-        }
-    });
-
-    // 파일 input의 내용이 변경(파일이 선택)되면, 이미지 미리보기를 생성합니다.
+    // 파일 input의 내용이 변경(파일이 선택)되면, 미리보기만 생성합니다.
     imageInput.addEventListener('change', () => {
         imagePreviewContainer.innerHTML = '';
+        selectedImageFiles = [];
+
         const files = imageInput.files;
         if (files.length > 0) {
-            Array.from(files).forEach(file => {
+            selectedImageFiles = Array.from(files);
+            selectedImageFiles.forEach(file => {
                 const reader = new FileReader();
                 reader.onload = (e) => {
                     const img = document.createElement('img');
@@ -38,46 +35,55 @@ export function initForumWrite() {
         }
     });
 
-    // 폼 제출 이벤트 처리 (헤더의 '공유' 버튼 또는 폼 제출 시)
+    // 폼 제출 이벤트 처리 ('공유' 버튼 클릭 시)
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
 
-        // '공유' 버튼 비활성화 (중복 제출 방지)
         submitButton.disabled = true;
         submitButton.textContent = '업로드 중...';
 
-        let imageUrls = [];
-        try {
-            const imageFiles = imageInput.files;
-            if (imageFiles.length > 0) {
-                const formData = new FormData();
-                for (let i = 0; i < imageFiles.length; i++) {
-                    formData.append("images", imageFiles[i]);
-                }
-                const imageUploadResponse = await fetch("/images/upload", {
-                    method: "POST",
-                    body: formData,
-                });
-                if (!imageUploadResponse.ok) {
-                    throw new Error("이미지 업로드에 실패했습니다.");
-                }
-                const imageData = await imageUploadResponse.json();
-                imageUrls = imageData.data;
-            }
-        } catch (error) {
-            console.error('이미지 업로드 오류:', error);
-            alert('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
+        const currentAreaKey = localStorage.getItem('currentAreaKey');
+        if (!currentAreaKey) {
+            alert('지역 설정이 필요합니다.');
             submitButton.disabled = false;
             submitButton.textContent = '공유';
             return;
         }
 
-        // 2단계: 이미지 URL을 포함한 게시글 데이터를 JSON으로 서버에 보냅니다.
+        let imageUrls = [];
+        try {
+            if (selectedImageFiles.length > 0) {
+                const formData = new FormData();
+                selectedImageFiles.forEach(file => {
+                    formData.append("images", file);
+                });
+
+                // 1단계: S3에 이미지 업로드 및 URL 목록 받기
+                const imageUploadResponse = await fetch("/images/upload", {
+                    method: "POST",
+                    body: formData,
+                });
+
+                if (!imageUploadResponse.ok) {
+                    const errorData = await imageUploadResponse.json();
+                    throw new Error(errorData.message || "이미지 업로드에 실패했습니다.");
+                }
+
+                const responseData = await imageUploadResponse.json();
+                imageUrls = responseData.data;
+            }
+        } catch (error) {
+            console.error('이미지 업로드 오류:', error);
+            alert(`이미지 업로드에 실패했습니다. (${error.message})`);
+            submitButton.disabled = false;
+            submitButton.textContent = '공유';
+            return;
+        }
+
+        // 2단계: 게시글 데이터와 이미지 URL 목록을 함께 전송
         const createForumData = {
-            writerId: document.getElementById("writerId").value,
             content: document.getElementById("content").value,
-            // location 값을 localStorage에서 가져와 설정
-            location: localStorage.getItem('currentAreaKey'),
+            location: currentAreaKey,
             imageUrls: imageUrls,
             spotifyTrackId: document.getElementById("spotifyTrackId").value,
             userEmail: "test@gmail.com",
@@ -87,24 +93,33 @@ export function initForumWrite() {
             const forumCreateResponse = await fetch("/forum", {
                 method: "POST",
                 headers: {
-                    "Content-Type": "application/json", // Content-Type을 application/json으로 명시
+                    "Content-Type": "application/json",
                 },
-                body: JSON.stringify(createForumData), // JSON.stringify로 데이터를 변환
+                body: JSON.stringify(createForumData),
             });
 
             if (!forumCreateResponse.ok) {
-                throw new Error("게시글 생성에 실패했습니다.");
+                const errorData = await forumCreateResponse.json();
+                throw new Error(errorData.message || "게시글 생성에 실패했습니다.");
             }
 
-            const forumData = await forumCreateResponse.json();
             alert("게시글이 성공적으로 작성되었습니다!");
             window.location.href = '/';
         } catch (error) {
             console.error('게시글 생성 오류:', error);
-            alert('오류가 발생했습니다. 다시 시도해주세요.');
+            alert(`오류가 발생했습니다. (${error.message}) 다시 시도해주세요.`);
         } finally {
             submitButton.disabled = false;
             submitButton.textContent = '공유';
+        }
+    });
+
+    // 음악 추가 버튼 클릭 시 동작
+    document.getElementById('add-music-btn').addEventListener('click', () => {
+        const trackId = prompt("연결할 Spotify 트랙 ID를 입력하세요:", "4uPiFjZpAfggB4aW2v2p4M");
+        if (trackId) {
+            document.getElementById('spotifyTrackId').value = trackId;
+            alert(`음악이 추가되었습니다: ${trackId}`);
         }
     });
 }

--- a/src/main/js/pages/main.js
+++ b/src/main/js/pages/main.js
@@ -114,6 +114,53 @@ export function initMain() {
         }
     });
 
+    // 수정/삭제 모달 로직
+    // '...' 버튼 클릭 시 모달창 표시
+    $('#post-list-container').on('click', '.post-options-button', function () {
+        const postId = $(this).data('forum-id');
+        $('#action-modal').data('current-post-id', postId).show();
+    });
+
+    // 수정 버튼 클릭
+    $('#edit-button').on('click', function () {
+        const postId = $('#action-modal').data('current-post-id');
+        window.location.href = `/forum/${postId}/edit`; // 수정 페이지로 이동
+    });
+
+    // 삭제 버튼 클릭
+    $('#delete-button').on('click', function () {
+        $('#action-modal').hide(); // 액션 모달 숨기기
+        $('#confirm-delete-modal').show(); // 삭제 확인 모달 표시
+    });
+
+    // 삭제 확인 모달의 '예' 버튼 클릭
+    $('#confirm-delete-yes').on('click', async function () {
+        const postId = $('#action-modal').data('current-post-id');
+        try {
+            const response = await fetch(`/forum/${postId}`, {
+                method: 'DELETE'
+            });
+
+            if (!response.ok) {
+                throw new Error('게시글 삭제에 실패했습니다.');
+            }
+
+            alert('게시글이 성공적으로 삭제되었습니다.');
+            // UI 업데이트
+            $(`.post-card[data-post-id="${postId}"]`).remove();
+            $('#confirm-delete-modal').hide();
+
+        } catch (error) {
+            console.error('삭제 오류:', error);
+            alert('삭제 중 오류가 발생했습니다.');
+        }
+    });
+
+    // 모달 닫기 버튼 또는 '아니오' 버튼 클릭
+    $('.modal .close-button, #confirm-delete-no').on('click', function () {
+        $(this).closest('.modal').hide();
+    });
+
 // key를 이용해 게시물을 불러오는 함수
     function loadPosts(key) {
         console.log(`'${key}' 지역의 게시물을 불러옵니다.`);
@@ -165,40 +212,49 @@ export function initMain() {
             post.recentLikerPhotos.map(photo => `<img src="${photo}" class="liker-profile-img">`).join('')
             : '';
 
+        //작성자에게만 수정/삭제 버튼을 표시
+        const optionsHtml = post.author ? `
+            <div class="post-options-container">
+                <button class="post-options-button" data-forum-id="${post.id}">...</button>
+            </div>
+        ` : '';
+
         return `
-       <div class="post-card" data-post-id="${post.id}">
-            <div class="post-author">
-                <img alt="${post.writerNickname}" src="${post.writerProfilePhotoUrl}" class="profile-img">
-                <div class="post-author-info">
-                    <div class="name">${post.writerNickname}</div>
-                    <div class="time">${timeAgoText}</div>
+           <div class="post-card" data-post-id="${post.id}">
+                <div class="post-header">
+                    <div class="post-author">
+                        <img alt="${post.writerNickname}" src="${post.writerProfilePhotoUrl}" class="profile-img">
+                        <div class="post-author-info">
+                            <div class="name">${post.writerNickname}</div>
+                            <div class="time">${timeAgoText}</div>
+                        </div>
+                    </div>
+                    ${optionsHtml} </div>
+                <div class="post-content">
+                    <p>${escapeHTML(post.contentsText)}</p>
+                    ${imagesHtml}
+                </div>
+                <div class="post-actions">
+                    <div>
+                        <span class="like-button" data-forum-id="${post.id}">
+                            <span class="like-icon">${likeIcon}</span>
+                            <span class="like-count">${post.totalLikes}</span> likes
+                        </span>
+                        <a class="comment-trigger" href="#">💬 <span class="comment-count">${post.totalComments}</span> comments</a>
+                    </div>
+                </div>
+                <div class="liker-photos">
+                    ${recentLikerPhotosHtml}
+                </div>
+                <div class="comment-section" style="display:none;">
+                    <ul class="comment-list"></ul>
+                    <form class="comment-form">
+                        <input class="comment-input" placeholder="댓글을 입력하세요..." required type="text">
+                        <button class="comment-submit" type="submit">게시</button>
+                    </form>
                 </div>
             </div>
-            <div class="post-content">
-                <p>${escapeHTML(post.contentsText)}</p>
-                ${imagesHtml}
-            </div>
-            <div class="post-actions">
-                <div>
-                    <span class="like-button" data-forum-id="${post.id}">
-                        <span class="like-icon">${likeIcon}</span>
-                        <span class="like-count">${post.totalLikes}</span> likes
-                    </span>
-                    <a class="comment-trigger" href="#">💬 <span class="comment-count">${post.totalComments}</span> comments</a>
-                </div>
-            </div>
-            <div class="liker-photos">
-                ${recentLikerPhotosHtml}
-            </div>
-            <div class="comment-section" style="display:none;">
-                <ul class="comment-list"></ul>
-                <form class="comment-form">
-                    <input class="comment-input" placeholder="댓글을 입력하세요..." required type="text">
-                    <button class="comment-submit" type="submit">게시</button>
-                </form>
-            </div>
-        </div>
-    `;
+        `;
     }
 
 // 좋아요 상태 업데이트 함수

--- a/src/main/resources/templates/forum/forum-edit.html
+++ b/src/main/resources/templates/forum/forum-edit.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>forum-edit</title>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <link href="/pwa/manifest.json" rel="manifest">
+    <script defer th:src="@{/js/bundle.js}"></script>
+</head>
+<body id="page-forum-edit">
+<header class="top-bar">
+    <button id="back-button">◀</button>
+    <div class="header-title">게시글 수정</div>
+    <button form="edit-forum-form" id="save-button" type="submit">완료</button>
+</header>
+<div class="main-container">
+    <form id="edit-forum-form" th:object="${forum}">
+        <input id="forum-id" th:value="*{id}" type="hidden">
+        <div class="form-group">
+            <textarea id="forum-content" placeholder="내용을 입력하세요..." required th:text="*{contentsText}"></textarea>
+        </div>
+        <div class="media-container">
+            <div class="media-list" id="image-container">
+                <div class="media-item" th:each="image : *{images}">
+                    <img alt="게시물 사진" th:src="${image.imgUrl}"/>
+                    <button class="delete-media-button" data-type="image" th:data-image-id="${image.id}" type="button">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            </div>
+            <div class="media-list" id="music-container" th:if="*{musicApiUrl}">
+                <div class="media-item music-item">
+                    <p>현재 음악</p>
+                    <input id="music-url-input" th:value="*{musicApiUrl}" type="hidden"/>
+                    <button class="delete-media-button" data-type="music" type="button">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/forum/main.html
+++ b/src/main/resources/templates/forum/main.html
@@ -20,6 +20,24 @@
 <div class="main-container">
 
     <div id="post-list-container"></div>
+    
+    <div class="modal" id="action-modal" style="display: none;">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <button class="modal-button" id="edit-button">수정</button>
+            <button class="modal-button" id="delete-button">삭제</button>
+        </div>
+    </div>
+
+    <div class="modal" id="confirm-delete-modal" style="display: none;">
+        <div class="modal-content">
+            <p>게시글을 정말 삭제하시겠습니까?</p>
+            <div class="modal-buttons">
+                <button class="modal-button confirm-yes" id="confirm-delete-yes">예</button>
+                <button class="modal-button confirm-no" id="confirm-delete-no">아니오</button>
+            </div>
+        </div>
+    </div>
 
     <div th:replace="~{fragment/main-nav :: mainNavFragment}"></div>
 </div>


### PR DESCRIPTION
## 구현 내용 요약
- 게시글 수정/삭제 기능 구현: 작성자에게만 수정 및 삭제 권한을 부여하고, UI를 통해 안전하게 게시글을 관리하는 기능을 추가했습니다.
- 이미지 관리 로직 개선: spring ex6의 원리를 적용, 이미지를 개별적으로 다루는 기반을 마련했습니다. 수정 페이지에서 이미지를 삭제해도 '완료' 버튼을 눌러야만 최종적으로 반영되는 안전한 사용자 경험(UX)을 구현했습니다.


---

## 관련 이슈
Closes #66 
Closes #67 

---

## 작업 상세 내역
- ForumController에 POST /forum/{forumId} (수정), DELETE /forum/{forumId} (삭제) 엔드포인트 추가
- ForumService에 updateForum, deleteForum 비즈니스 로직 및 작성자 권한 검증 로직 구현
- ForumUpdateRequestDto 등 수정에 필요한 DTO 구조 재설계
- ForumImageService에 deletedImageIds를 이용한 선택적 이미지 삭제 로직 추가
- main 페이지에 작성자에게만 보이는 ... 버튼 및 수정/삭제 모달창 구현
- forum-edit 페이지에 기존 게시글 데이터(이미지 ID 포함)를 불러오는 기능 구현
- 'X' 버튼 클릭 시 이미지를 화면에서만 숨기고 ID를 임시 저장하는 로직 구현
- '완료' 버튼 클릭 시 삭제할 이미지 ID 목록을 포함한 최종 수정 요청을 서버에 전송

---

## from to
<feature/forum-post-edit-delete> -> <develop>

---