### PR TITLE
[feat] : 메인 페이지 내 Fin'd 작성 및 Park 작성 페이지로 이동 기능 구현

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 /gradlew text eol=lf
 *.bat text eol=crlf
 *.jar binary
+* text=auto

--- a/src/main/java/io/github/nokasegu/post_here/find/controller/FindController.java
+++ b/src/main/java/io/github/nokasegu/post_here/find/controller/FindController.java
@@ -3,20 +3,17 @@ package io.github.nokasegu.post_here.find.controller;
 import io.github.nokasegu.post_here.find.service.FindService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/test")
 public class FindController {
 
     private final FindService findService;
 
-    @GetMapping("/find")
-    @ResponseBody
-    public String testController(){
-        return "hello";
+    @GetMapping("/find-write")
+    public String findController(Model model){
+        return "/find/find-write";
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/park/controller/ParkController.java
+++ b/src/main/java/io/github/nokasegu/post_here/park/controller/ParkController.java
@@ -3,10 +3,16 @@ package io.github.nokasegu.post_here.park.controller;
 import io.github.nokasegu.post_here.park.service.ParkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 @RequiredArgsConstructor
 public class ParkController {
 
     private final ParkService parkService;
+
+    @GetMapping("/park-write")
+    public String parkWrite() {
+        return "/park/park-write";
+    }
 }

--- a/src/main/resources/templates/fragment/main-nav.html
+++ b/src/main/resources/templates/fragment/main-nav.html
@@ -14,6 +14,8 @@
             <a href="/">🏠</a>
             <a href="/messages">✉️</a>
             <a href="/forum">📝</a>
+            <a href="/find-write">Fin'd 작성</a>
+            <a href="/park-write">Park 작성</a>
 
             <!-- 🔔 종 아이콘에 빨간 점 추가 (링크 경로는 /notification) -->
             <!-- [역할] 네비게이션의 알림 상태 표시. 서버의 /notification/unread-count 결과에 따라 표시/숨김 -->


### PR DESCRIPTION
## 구현 내용 요약
- 메인 페이지에서 'Fin'd 작성' 및 'Park 작성' 페이지로 이동하는 기능을 구현
- 각 작성 페이지에 대한 서버 라우팅(URL 매핑)을 추가

---

## 관련 이슈
Closes #76

---

## 작업 상세 내역
- 메인 페이지: Fin'd 및 Park 작성 페이지로 이동하는 하이퍼링크(<a> 태그)를 추가
- 컨트롤러: '/find/write' 및 '/profile/park' 경로 요청 시, 각각의 HTML 뷰를 반환하는 메소드를 추가

---

## from to
`feature/link-to-find` -> `main`

---