### PR TITLE
<feat> : 프로필 페이지 프론트 엔드와 회원정보 창 프론트 엔드 완료(html,js,css)

### DIFF
--- a/src/main/js/pages/profile.js
+++ b/src/main/js/pages/profile.js
@@ -1,73 +1,227 @@
 export function initProfile() {
 
-    const profileImageContainer = document.getElementById('profileImageContainer');
-    const profileImageInput = document.getElementById('profileImageInput');
-    const profileImage = document.getElementById('profileImage');
-    const saveButton = document.getElementById('saveButton');
-    const statusMessage = document.getElementById('statusMessage');
+    // --- Mock Data (예시 데이터) ---
+    const findsData = [
+        {
+            id: 1,
+            imageUrl: 'https://images.unsplash.com/photo-1597362925123-5165345093a3?q=80&w=400&auto=format&fit=crop',
+            location: 'Samsung-dong',
+            isExpiring: true
+        },
+        {
+            id: 2,
+            imageUrl: 'https://images.unsplash.com/photo-1588622146903-04938971f153?q=80&w=400&auto=format&fit=crop',
+            location: 'Sungsu-dong',
+            isExpiring: false
+        },
+        {
+            id: 3,
+            imageUrl: 'https://images.unsplash.com/photo-1519996529649-34b33d7935d2?q=80&w=400&auto=format&fit=crop',
+            location: 'Gangnam',
+            isExpiring: false
+        },
+        {
+            id: 4,
+            imageUrl: 'https://images.unsplash.com/photo-1582287135311-8c4f8d2b9f10?q=80&w=400&auto=format&fit=crop',
+            location: 'Hongdae',
+            isExpiring: true
+        },
+    ];
+    const forumsData = [
+        {
+            id: 1,
+            imageUrl: 'https://images.unsplash.com/photo-1543364195-077a16c30ff3?q=80&w=400&auto=format&fit=crop',
+            location: 'Jamsil'
+        },
+        {
+            id: 2,
+            imageUrl: 'https://images.unsplash.com/photo-1585154392221-516752dd132f?q=80&w=400&auto=format&fit=crop',
+            location: 'Itaewon'
+        },
+        {
+            id: 3,
+            imageUrl: 'https://images.unsplash.com/photo-1621282243983-50e5a5933a39?q=80&w=400&auto=format&fit=crop',
+            location: 'Sinsa'
+        },
+        {
+            id: 4,
+            imageUrl: 'https://images.unsplash.com/photo-1563237023-b1e970526dcb?q=80&w=400&auto=format&fit=crop',
+            location: 'Myeong-dong'
+        },
+    ];
 
-// 1. 프로필 이미지 영역 클릭 시, 숨겨진 파일 입력 필드 클릭
-    profileImageContainer.addEventListener('click', () => {
-        profileImageInput.click();
+    // --- UI Element References ---
+    const openEditModalBtn = document.getElementById('open-edit-modal-btn');
+    const editProfileModal = document.getElementById('edit-profile-modal');
+    const cancelEditBtn = document.getElementById('cancel-edit-btn');
+    const openPasswordModalBtn = document.getElementById('open-password-modal-btn');
+    const nicknameInput = document.getElementById('nickname');
+    const checkNicknameBtn = document.getElementById('check-nickname-btn');
+    const nicknameFeedback = document.getElementById('nickname-feedback');
+    const changePasswordModal = document.getElementById('change-password-modal');
+    const newPasswordInput = document.getElementById('new-password');
+    const confirmPasswordInput = document.getElementById('confirm-password');
+    const passwordFeedback = document.getElementById('password-feedback');
+    const updatePasswordBtn = document.getElementById('update-password-btn');
+    const cancelPasswordBtn = document.getElementById('cancel-password-btn');
+    const tabFind = document.getElementById('tab-find');
+    const tabForum = document.getElementById('tab-forum');
+    const carousel = document.getElementById('carousel');
+    const carouselWrapper = document.getElementById('carousel-wrapper');
+
+    let currentTab = 'find', currentPage = 0;
+    const postsPerPage = 2;
+    let isNicknameAvailable = false;
+    let newPassword = null;
+
+    // --- Modal Logic ---
+    function openModal(modal) {
+        if (modal) modal.style.display = 'flex';
+    }
+
+    function closeModal(modal) {
+        if (modal) modal.style.display = 'none';
+    }
+
+    if (openEditModalBtn) openEditModalBtn.addEventListener('click', () => openModal(editProfileModal));
+    if (cancelEditBtn) cancelEditBtn.addEventListener('click', () => closeModal(editProfileModal));
+    if (openPasswordModalBtn) openPasswordModalBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        closeModal(editProfileModal);
+        openModal(changePasswordModal);
+    });
+    if (cancelPasswordBtn) cancelPasswordBtn.addEventListener('click', () => {
+        closeModal(changePasswordModal);
+        openModal(editProfileModal);
     });
 
-// 2. 사용자가 파일을 선택했을 때의 처리
-    profileImageInput.addEventListener('change', (event) => {
-        const file = event.target.files[0];
-        if (!file) {
-            return; // 파일 선택 취소 시 아무것도 하지 않음
-        }
-
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            profileImage.src = e.target.result;
-        };
-        reader.readAsDataURL(file);
-
-        // 'Save Changes' 버튼을 보여줌 (클래스명 변경에 따라 수정)
-        saveButton.classList.add('visible');
-        statusMessage.textContent = '';
-    });
-
-// 3. 'Save Changes' 버튼 클릭 시, 서버로 이미지 전송
-    saveButton.addEventListener('click', async () => {
-        const file = profileImageInput.files[0];
-        if (!file) {
-            alert('Please select an image file.');
+    if (checkNicknameBtn) checkNicknameBtn.addEventListener('click', () => {
+        const nickname = nicknameInput.value;
+        if (!nickname) {
+            nicknameFeedback.textContent = '닉네임을 입력해주세요.';
+            nicknameFeedback.style.color = 'red';
+            isNicknameAvailable = false;
             return;
         }
-
-        const formData = new FormData();
-        formData.append('profileImage', file);
-
-        saveButton.disabled = true;
-        saveButton.textContent = 'Saving...';
-        statusMessage.textContent = '';
-
-        try {
-            const response = await fetch('/api/profile/image', {
-                method: 'POST',
-                body: formData,
-            });
-
-            if (!response.ok) {
-                throw new Error('Image upload failed. Please try again.');
+        // This is a simulation of an API call
+        setTimeout(() => {
+            if (nickname.toLowerCase() === 'admin') {
+                nicknameFeedback.textContent = '닉네임 변경 불가!';
+                nicknameFeedback.style.color = 'red';
+                isNicknameAvailable = false;
+            } else {
+                nicknameFeedback.textContent = '닉네임 변경 가능!';
+                nicknameFeedback.style.color = 'green';
+                isNicknameAvailable = true;
             }
-
-            const result = await response.json();
-
-            statusMessage.textContent = 'Profile image updated successfully!';
-            statusMessage.style.color = 'rgb(34 197 94)';
-
-            // 버튼 숨기기 (클래스명 변경에 따라 수정)
-            saveButton.classList.remove('visible');
-
-        } catch (error) {
-            statusMessage.textContent = error.message;
-            statusMessage.style.color = 'rgb(239 68 68)';
-        } finally {
-            saveButton.disabled = false;
-            saveButton.textContent = 'Save Changes';
-        }
+        }, 500);
     });
+
+    function validatePassword() {
+        if (newPasswordInput.value && newPasswordInput.value === confirmPasswordInput.value) {
+            passwordFeedback.textContent = '비밀번호가 일치합니다.';
+            passwordFeedback.style.color = 'green';
+            updatePasswordBtn.disabled = false;
+        } else {
+            passwordFeedback.textContent = '비밀번호가 일치하지 않습니다.';
+            passwordFeedback.style.color = 'red';
+            updatePasswordBtn.disabled = true;
+        }
+    }
+
+    if (newPasswordInput) newPasswordInput.addEventListener('input', validatePassword);
+    if (confirmPasswordInput) confirmPasswordInput.addEventListener('input', validatePassword);
+
+    const changePasswordForm = document.getElementById('change-password-form');
+    if (changePasswordForm) changePasswordForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        newPassword = newPasswordInput.value;
+        alert('비밀번호가 임시 저장되었습니다. Update 버튼을 눌러 최종 적용하세요.');
+        closeModal(changePasswordModal);
+        openModal(editProfileModal);
+    });
+
+    const editProfileForm = document.getElementById('edit-profile-form');
+    if (editProfileForm) editProfileForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        let updateMessage = '프로필 업데이트:';
+        if (isNicknameAvailable && nicknameInput.value) {
+            updateMessage += `\n- 새 닉네임: ${nicknameInput.value}`;
+        }
+        if (newPassword) {
+            updateMessage += `\n- 새 비밀번호 설정 완료`;
+        }
+        alert(updateMessage);
+        closeModal(editProfileModal);
+    });
+
+    // --- Carousel and Tab Logic ---
+    function renderContent() {
+        if (!carousel) return;
+        const data = currentTab === 'find' ? findsData : forumsData;
+        const totalPages = Math.ceil(data.length / postsPerPage);
+        carousel.innerHTML = '';
+        if (totalPages === 0) {
+            carousel.innerHTML = `<div style="text-align:center;width:100%;color:var(--secondary-text-color);">게시물이 없습니다.</div>`;
+            return;
+        }
+        carousel.style.width = `${totalPages * 100}%`;
+        for (let i = 0; i < totalPages; i++) {
+            const pageElement = document.createElement('div');
+            pageElement.className = 'content-page';
+            let pageHTML = '';
+            const pageData = data.slice(i * postsPerPage, (i + 1) * postsPerPage);
+            pageData.forEach(post => {
+                const postLink = currentTab === 'find' ? `/find-detail/${post.id}` : `/forum-detail/${post.id}`;
+                const statusIcon = post.isExpiring ? '<div class="post-item__status-icon">⏰</div>' : '';
+                pageHTML += `<a href="${postLink}" class="post-item"><img class="post-item__image" src="${post.imageUrl}" alt="Post image">${statusIcon}<p class="post-item__location">📍 ${post.location}</p></a>`;
+            });
+            pageElement.innerHTML = pageHTML;
+            carousel.appendChild(pageElement);
+        }
+        goToPage(0);
+    }
+
+    function goToPage(pageIndex) {
+        if (!carousel) return;
+        const data = currentTab === 'find' ? findsData : forumsData;
+        const totalPages = Math.ceil(data.length / postsPerPage) || 1;
+        if (pageIndex < 0) pageIndex = 0;
+        if (pageIndex >= totalPages) pageIndex = totalPages - 1;
+        currentPage = pageIndex;
+        const offset = -currentPage * (100 / totalPages);
+        carousel.style.transform = `translateX(${offset}%)`;
+    }
+
+    if (tabFind) tabFind.addEventListener('click', () => {
+        if (currentTab === 'find') return;
+        currentTab = 'find';
+        tabFind.classList.add('active');
+        tabForum.classList.remove('active');
+        renderContent();
+    });
+    if (tabForum) tabForum.addEventListener('click', () => {
+        if (currentTab === 'forum') return;
+        currentTab = 'forum';
+        tabForum.classList.add('active');
+        tabFind.classList.remove('active');
+        renderContent();
+    });
+
+    let touchStartX = 0;
+    if (carouselWrapper) {
+        carouselWrapper.addEventListener('touchstart', (e) => {
+            touchStartX = e.touches[0].clientX;
+        }, {passive: true});
+        carouselWrapper.addEventListener('touchend', (e) => {
+            const touchEndX = e.changedTouches[0].clientX;
+            const swipeDistance = touchEndX - touchStartX;
+            if (swipeDistance < -50) goToPage(currentPage + 1);
+            else if (swipeDistance > 50) goToPage(currentPage - 1);
+        }, {passive: true});
+    }
+
+    // --- Initial Render ---
+    renderContent();
 }
+

--- a/src/main/resources/static/css/profile.css
+++ b/src/main/resources/static/css/profile.css
@@ -1,191 +1,360 @@
 :root {
-    --bg-light: #f3f4f6;
-    --bg-dark: #111827;
-    --card-bg-light: #ffffff;
-    --card-bg-dark: #1f2937;
-    --text-light: #111827;
-    --text-dark: #f9fafb;
-    --text-secondary-light: #6b7280;
-    --text-secondary-dark: #9ca3af;
-    --border-light: #e5e7eb;
-    --border-dark: #4b5563;
-    --accent-color: #4f46e5;
-    --accent-hover: #4338ca;
+    --background-color: #ffffff;
+    --container-color: #ffffff;
+    --primary-text-color: #000000;
+    --secondary-text-color: #8E8E93;
+    --border-color: #E5E5EA;
+    --my-gradient-start: #D8EAD2;
+    --my-gradient-end: #A2C49A;
+    --my-button-bg: #89B380;
+    --other-gradient-start: #E9D5FF;
+    --other-gradient-end: #C8B6E2;
+    --other-button-bg: #A38BC2;
+    --tab-inactive-bg: #f0f0f0;
+    --tab-active-bg: #333333;
+    --guestbook-bg: #f7f7f7;
+    --input-bg: #F7F7F7;
+}
+
+html, body {
+    height: 100%;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f0f2f5;
 }
 
 body {
-    font-family: 'Inter', sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--bg-light);
-    color: var(--text-light);
     display: flex;
-    align-items: center;
     justify-content: center;
-    min-height: 100vh;
-    margin: 0;
 }
 
-/* 다크 모드 지원 */
-@media (prefers-color-scheme: dark) {
-    body {
-        background-color: var(--bg-dark);
-        color: var(--text-dark);
-    }
+a {
+    text-decoration: none;
+    color: inherit;
 }
 
-/* --- 컴포넌트 스타일 --- */
-
-/* 전체 프로필 카드를 감싸는 컨테이너 */
-.profile-card {
+.mobile-container {
     width: 100%;
-    max-width: 384px; /* max-w-sm */
-    background-color: var(--card-bg-light);
-    border-radius: 1rem; /* rounded-2xl */
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); /* shadow-lg */
-    padding: 24px; /* p-6 */
-}
-
-@media (prefers-color-scheme: dark) {
-    .profile-card {
-        background-color: var(--card-bg-dark);
-    }
-}
-
-.profile-content {
+    max-width: 450px;
+    height: 100%;
+    background-color: var(--background-color);
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
-    align-items: center;
+    overflow: hidden;
 }
 
-/* 프로필 이미지 */
-.profile-image-wrapper {
-    position: relative;
+.main-content {
+    flex-grow: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+/* --- 회원 정보 영역 --- */
+.profile-header-wrapper {
+    padding: 1.5rem 1rem;
+}
+
+.profile-header {
+    padding: 1rem;
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    background: radial-gradient(circle at top right, var(--my-gradient-start), var(--my-gradient-end));
+}
+
+.profile-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.profile-info__pic-label {
     cursor: pointer;
 }
 
-#profileImage {
-    width: 7rem; /* w-28 */
-    height: 7rem; /* h-28 */
-    border-radius: 9999px; /* rounded-full */
+.profile-info__pic {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
     object-fit: cover;
-    border: 4px solid var(--border-light);
+    border: 2px solid rgba(255, 255, 255, 0.5);
 }
 
-@media (prefers-color-scheme: dark) {
-    #profileImage {
-        border-color: var(--border-dark);
-    }
+.profile-info__text {
+    flex-grow: 1;
 }
 
-.image-overlay {
-    position: absolute;
-    inset: 0;
-    background-color: rgba(0, 0, 0, 0.5);
-    border-radius: 9999px;
+.profile-info__name {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.profile-stats {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.8rem;
+    opacity: 0.9;
+}
+
+.profile-action-btn {
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 0;
-    transition: opacity 0.3s ease-in-out;
-}
-
-.profile-image-wrapper:hover .image-overlay {
-    opacity: 1;
-}
-
-.image-overlay .icon {
-    color: white;
-    font-size: 1.5rem; /* text-2xl */
-}
-
-/* 사용자 정보 */
-.user-info .nickname {
-    font-size: 1.5rem; /* text-2xl */
-    font-weight: 700;
-    margin-top: 1rem; /* mt-4 */
-}
-
-.user-info .email {
-    color: var(--text-secondary-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    .user-info .email {
-        color: var(--text-secondary-dark);
-    }
-}
-
-.user-stats {
-    display: flex;
-    gap: 1.5rem; /* space-x-6 */
-    margin-top: 1rem; /* mt-4 */
-    text-align: center;
-}
-
-.user-stats .stat-value {
-    font-weight: 700;
-    font-size: 1.125rem; /* text-lg */
-}
-
-.user-stats .stat-label {
-    font-size: 0.875rem; /* text-sm */
-    color: var(--text-secondary-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    .user-stats .stat-label {
-        color: var(--text-secondary-dark);
-    }
-}
-
-/* 자기소개 */
-.bio {
-    margin-top: 1.5rem; /* mt-6 */
-    text-align: center;
-    color: var(--text-secondary-light);
-}
-
-@media (prefers-color-scheme: dark) {
-    .bio {
-        color: var(--text-secondary-dark);
-    }
-}
-
-/* 버튼 */
-.btn-save {
-    display: none; /* 기본적으로 숨김 */
-    margin-top: 1.5rem; /* mt-6 */
-    width: 100%;
-    background-color: var(--accent-color);
-    color: white;
-    font-weight: 700;
-    padding: 0.5rem 1rem; /* py-2 px-4 */
-    border-radius: 0.5rem; /* rounded-lg */
-    border: none;
+    font-weight: bold;
+    font-size: 1.2rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     cursor: pointer;
-    transition: background-color 0.3s;
+    border: none;
+    color: white;
+    background-color: var(--my-button-bg);
 }
 
-.btn-save:hover {
-    background-color: var(--accent-hover);
+.guestbook-wrapper {
+    padding: 0 1rem 1.5rem 1rem;
 }
 
-.btn-save:disabled {
-    opacity: 0.7;
-    cursor: not-allowed;
+.guestbook {
+    background-color: var(--guestbook-bg);
+    padding: 1rem;
+    border-radius: 16px;
 }
 
-.btn-save.visible {
+.guestbook__content {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: #333;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+}
+
+.posts-section {
+    padding: 0 1rem 1.5rem 1rem;
+}
+
+.content-tabs {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.content-tabs__button {
+    font-size: 1rem;
+    font-weight: bold;
+    color: var(--secondary-text-color);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    border: none;
+    background: var(--tab-inactive-bg);
+    border-radius: 20px;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.content-tabs__button.active {
+    color: white;
+    background: var(--tab-active-bg);
+}
+
+.content-carousel-wrapper {
+    overflow: hidden;
+}
+
+.content-carousel {
+    display: flex;
+    transition: transform 0.3s ease-in-out;
+}
+
+.content-page {
+    width: 100%;
+    flex-shrink: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.post-item {
+    position: relative;
+}
+
+.post-item__image {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: 12px;
     display: block;
 }
 
-/* 상태 메시지 */
-.status-message {
-    margin-top: 1rem; /* mt-4 */
-    font-size: 0.875rem; /* text-sm */
-    height: 1.25rem; /* h-5 */
+.post-item__status-icon {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary-text-color);
+    font-size: 0.8rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-/* 유틸리티 */
-#profileImageInput {
+.post-item__location {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 0.5rem;
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.bottom-nav {
+    flex-shrink: 0;
+    background-color: var(--background-color);
+    border-top: 1px solid var(--border-color);
+}
+
+.bottom-nav nav {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    height: 4.5rem;
+    padding-bottom: 1rem;
+}
+
+.bottom-nav a {
+    color: var(--secondary-text-color);
+    font-size: 1.75rem;
+}
+
+.bottom-nav a.active {
+    color: var(--primary-text-color);
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
     display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background-color: white;
+    padding: 2rem;
+    border-radius: 16px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    width: 90%;
+    max-width: 350px;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.modal-logo {
+    font-family: 'Times New Roman', Times, serif;
+    font-weight: bold;
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.modal-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 2rem;
+}
+
+.input-group {
+    text-align: left;
+    margin-bottom: 1rem;
+}
+
+.input-group label {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    color: var(--secondary-text-color);
+}
+
+.input-group input {
+    width: 100%;
+    padding: 0.8rem 1rem;
+    border: 1px solid var(--border-color);
+    background-color: var(--input-bg);
+    border-radius: 8px;
+    font-size: 1rem;
+    box-sizing: border-box;
+}
+
+.input-group .feedback-message {
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+    height: 1em;
+}
+
+.input-group-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.input-group-row input {
+    flex-grow: 1;
+}
+
+.button-group {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.modal-button {
+    flex: 1;
+    padding: 0.8rem;
+    border: none;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.btn-secondary {
+    background-color: #EFEFF4;
+    color: var(--primary-text-color);
+}
+
+.btn-primary {
+    background-color: var(--my-button-bg);
+    color: white;
+}
+
+.btn-primary:disabled {
+    background-color: #ccc;
+}
+
+.message-container {
+    width: 100%;
+    text-align: center;
+    color: var(--secondary-text-color);
+    padding-top: 2rem;
 }

--- a/src/main/resources/templates/userInfo/profile.html
+++ b/src/main/resources/templates/userInfo/profile.html
@@ -1,146 +1,121 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <title>Profile</title>
-    <!-- Font Awesome 아이콘 CDN -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <link rel="stylesheet" th:href="@{/css/profile.css}">
+    <meta content="width=device-width, initial-scale=1.0, user-scalable=no" name="viewport">
+    <title>Profile - PostHere</title>
+    <link href="/pwa/manifest.json" rel="manifest">
     <script defer th:src="@{/js/bundle.js}"></script>
+    <link rel="stylesheet" th:href="@{/css/index.css}">
+    <link rel="stylesheet" th:href="@{/css/profile.css}">
 </head>
 <body id="page-profile">
 
-<div class="profile-card">
-    <div class="profile-content">
-
-        <!-- 프로필 사진 섹션 -->
-        <div class="profile-image-wrapper" id="profileImageContainer">
-            <img alt="Profile image" id="profileImage" src="https://placehold.co/112x112/E2E8F0/4A5568?text=User">
-            <div class="image-overlay">
-                <i class="fas fa-camera icon"></i>
-            </div>
-        </div>
-        <input accept="image/*" id="profileImageInput" name="profileImage" type="file">
-
-        <!-- 사용자 정보 -->
-        <div class="user-info">
-            <h2 class="nickname" id="nickname">Watermelon</h2>
-            <p class="email" id="email">user@example.com</p>
-        </div>
-
-        <div class="user-stats">
-            <div>
-                <p class="stat-value">6</p>
-                <p class="stat-label">Follower</p>
-            </div>
-            <div>
-                <p class="stat-value">2</p>
-                <p class="stat-label">Following</p>
-            </div>
+<div class="mobile-container">
+    <main class="main-content">
+        <!-- Section 1: 회원 정보 -->
+        <div class="profile-header-wrapper">
+            <section class="profile-header">
+                <div class="profile-info">
+                    <label class="profile-info__pic-label" for="profile-image-upload">
+                        <img alt="Profile Picture"
+                             class="profile-info__pic"
+                             src="https://images.unsplash.com/photo-1528825871115-3581a5387919?q=80&w=256&auto=format&fit=crop">
+                    </label>
+                    <input accept="image/*" id="profile-image-upload" style="display: none;" type="file">
+                    <div class="profile-info__text">
+                        <h2 class="profile-info__name">Watermelon</h2>
+                        <div class="profile-stats">
+                            <a href="/followers"><span>Follower 6</span></a>
+                            <a href="/following"><span>Following 2</span></a>
+                        </div>
+                    </div>
+                </div>
+                <button class="profile-action-btn" id="open-edit-modal-btn">&gt;&gt;</button>
+            </section>
         </div>
 
-        <!-- 자기소개 -->
-        <p class="bio">
-            Yoshihiro Togashi created not just an adventure, but a profound exploration of humanity.
-        </p>
+        <!-- Section 2: PARK명록 -->
+        <div class="guestbook-wrapper">
+            <a href="/park-guestbook-detail">
+                <section class="guestbook">
+                    <p class="guestbook__content">
+                        Yoshihiro Togashi created not just an adventure, but a profound exploration of humanity, making
+                        Hunter × Hunter one of the greatest works in manga and anime history.
+                    </p>
+                </section>
+            </a>
+        </div>
 
-        <!-- 저장 버튼 (이미지 변경 시 나타남) -->
-        <button class="btn-save" id="saveButton">
-            Save Changes
-        </button>
+        <!-- Section 3: Fin'd / Forum -->
+        <section class="posts-section">
+            <div class="content-tabs">
+                <button class="content-tabs__button active" id="tab-find">Fin'd <span>&gt;</span></button>
+                <button class="content-tabs__button" id="tab-forum">Forum <span>&gt;</span></button>
+            </div>
+            <div class="content-carousel-wrapper" id="carousel-wrapper">
+                <div class="content-carousel" id="carousel"></div>
+            </div>
+        </section>
+    </main>
 
-        <!-- 상태 메시지 영역 -->
-        <p class="status-message" id="statusMessage"></p>
+    <footer class="bottom-nav">
+        <nav><a href="#">🏠</a> <a href="#">✉️</a> <a href="#">✏️</a> <a href="#">🔔</a> <a class="active" href="#">👤</a>
+        </nav>
+    </footer>
+</div>
+
+<!-- Edit Profile Modal -->
+<div class="modal-overlay" id="edit-profile-modal">
+    <div class="modal-content">
+        <h1 class="modal-logo">PostHere</h1>
+        <p class="modal-title">Edit your profile</p>
+        <form id="edit-profile-form">
+            <div class="input-group">
+                <label for="nickname">Nickname</label>
+                <div class="input-group-row">
+                    <input id="nickname" name="nickname" placeholder="Enter new nickname" required type="text">
+                    <button class="modal-button btn-secondary" id="check-nickname-btn" type="button">Check</button>
+                </div>
+                <p class="feedback-message" id="nickname-feedback"></p>
+            </div>
+            <div class="input-group">
+                <label>Password</label>
+                <button class="modal-button btn-secondary" id="open-password-modal-btn" type="button">Change Password
+                </button>
+            </div>
+            <div class="button-group">
+                <button class="modal-button btn-secondary" id="cancel-edit-btn" type="button">Cancel</button>
+                <button class="modal-button btn-primary" id="update-profile-btn" type="submit">Update</button>
+            </div>
+        </form>
     </div>
 </div>
-<script>
-    // 병합 양식 상 붙여놓은 js, 나중에 지울 예정
-    function authHeaders(base = {}) {
-        const headers = {...base};
-        const token = document.querySelector('meta[name="_csrf"]')?.content || '';
-        const headerName = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
-        if (token) headers[headerName] = token;
-        return headers;
-    }
 
-    const serverUserId = document.querySelector('meta[name="profileUserId"]')?.content;
-    const targetId = serverUserId || location.pathname.split('/').pop();
-    const btn = document.getElementById('followBtn');
-
-    async function getUserBrief(id) {
-        const res = await fetch(`/profile/info/${id}`, {headers: authHeaders({'Accept': 'application/json'})});
-        if (!res.ok) throw new Error('유저 정보 불러오기 실패');
-        return res.json();
-    }
-
-    async function getStatus(id) {
-        const res = await fetch('/friend/status', {
-            method: 'POST',
-            headers: authHeaders({'Content-Type': 'application/json', 'Accept': 'application/json'}),
-            body: JSON.stringify({ids: [Number(id)]})
-        });
-        if (!res.ok) return false;
-        const data = await res.json();
-        return !!(data?.status?.[id]);
-    }
-
-    async function apiFollow(id) {
-        const res = await fetch('/friend/addfollowing', {
-            method: 'POST',
-            headers: authHeaders({'Accept': 'application/json', 'Content-Type': 'application/json'}),
-            body: JSON.stringify({userId: Number(id)})
-        });
-        if (!res.ok) throw new Error('팔로우 실패 (HTTP ' + res.status + ')');
-        return res.json();
-    }
-
-    async function apiUnfollow(id) {
-        const res = await fetch('/friend/unfollowing', {
-            method: 'DELETE',
-            headers: authHeaders({'Accept': 'application/json', 'Content-Type': 'application/json'}),
-            body: JSON.stringify({userId: Number(id)})
-        });
-        if (!res.ok) throw new Error('언팔로우 실패 (HTTP ' + res.status + ')');
-        return res.json();
-    }
-
-    function renderButton(following) {
-        btn.textContent = following ? '삭제' : '친구 추가';
-        btn.onclick = async () => {
-            try {
-                if (following) {
-                    await apiUnfollow(targetId);
-                    following = false;
-                } else {
-                    await apiFollow(targetId);
-                    following = true;
-                }
-                renderButton(following);
-            } catch (e) {
-                alert(e.message || '요청 실패');
-            }
-        };
-    }
-
-    (async function init() {
-        try {
-            const brief = await getUserBrief(targetId);
-            document.getElementById('nickname').textContent = brief.nickname || `(No name)`;
-            document.getElementById('userId').textContent = `#${brief.id}`;
-            const avatar = document.getElementById('avatar');
-            avatar.src = brief.profilePhotoUrl || `https://picsum.photos/seed/${brief.id}/160/160`;
-            avatar.onerror = () => avatar.style.visibility = 'hidden';
-
-            const following = await getStatus(targetId);
-            renderButton(following);
-        } catch (e) {
-            btn.textContent = '오류';
-            btn.disabled = true;
-            alert(e.message || '초기 로딩 실패');
-        }
-    })();
-</script>
+<!-- Change Password Modal -->
+<div class="modal-overlay" id="change-password-modal">
+    <div class="modal-content">
+        <h1 class="modal-logo">PostHere</h1>
+        <p class="modal-title">Change your password</p>
+        <form id="change-password-form">
+            <div class="input-group">
+                <label for="new-password">New Password</label>
+                <input id="new-password" name="new-password" required type="password">
+            </div>
+            <div class="input-group">
+                <label for="confirm-password">Confirm Password</label>
+                <input id="confirm-password" name="confirm-password" required type="password">
+                <p class="feedback-message" id="password-feedback"></p>
+            </div>
+            <div class="button-group">
+                <button class="modal-button btn-secondary" id="cancel-password-btn" type="button">Cancel</button>
+                <button class="modal-button btn-primary" disabled id="update-password-btn" type="submit">Update
+                    Password
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
 </body>
 </html>
 


### PR DESCRIPTION
## 구현 내용 요약
프로필 페이지와 회원정보 수정 프론트 엔드 구현

---

## 관련 이슈
#50

---

## 작업 상세 내역
- 프로필 페이지에서 회원 칸,park명록, fin'd와 forum 기능들을 전부 보이게 할 예정
- 회원 칸에서 자신이 사용하는 이미지와 닉네임, follower, following이 보이도록 하고 각각을 누르면 관련된 페이지로 이동할 수 있도록 할 예정
- 프로필 페이지에 park명록을 띄우고 누르면 park명록을 더 크게 보일 수 있는 페이지로 이동하게 할 예정.
- fin'd와 forum 기능을 담당하는 칸을 만들거임.
- fin'd 버튼을 누르면 fin'd가 나옴, fin'd에서 어디서 작성했는지 나와야 하며, 유효 시간이 남아있는 표시를 fin'd에 나타내게 할 예정
- fin'd를 누르면 fin'd 확대해서 볼 수 있는 페이지로 넘어간다.
- fin'd는 옆으로 넘기는 방식으로 할 예정
- 회원정보 수정칸을 modal창으로 만들었음.
-  닉네임 중복 확인 창
- 비밀번호 확인 모달 창을 하나도 만들었음


---

## from to
<feature/profile-frontend> -> <main>

---