### PR TITLE
[기능] 전역 알림 배지(종아이콘 빨간 점) + 읽음 처리 단일 엔드포인트 적용

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/notification/controller/NotificationReadController.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/controller/NotificationReadController.java
@@ -1,0 +1,61 @@
+package io.github.nokasegu.post_here.notification.controller;
+
+import io.github.nokasegu.post_here.notification.service.NotificationService;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 읽음 처리 단일 엔드포인트
+ * - 규칙: /notification 뒤에 다른 경로 세그먼트 금지
+ * - 전체 읽음: {} 또는 {"all": true}
+ * - 선택 읽음: {"ids":[1,2,3]}
+ */
+@RestController
+@RequiredArgsConstructor
+public class NotificationReadController {
+
+    private final NotificationService notificationService;
+    private final UserInfoRepository userRepo;
+
+    private Long resolveUserId(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 필요");
+        }
+        // principal.getName()은 email
+        UserInfoEntity byEmail = userRepo.findByEmail(principal.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 없음"));
+        return byEmail.getId();
+    }
+
+    @PostMapping(value = "/notification", consumes = "application/json", produces = "application/json")
+    public Map<String, Integer> read(Principal principal, @RequestBody(required = false) ReadRequest body) {
+        Long me = resolveUserId(principal);
+
+        // ids가 있으면 선택 읽음, 아니면 전체 읽음
+        int updated;
+        if (body != null && body.getIds() != null && !body.getIds().isEmpty()) {
+            updated = notificationService.markRead(me, body.getIds());
+        } else {
+            updated = notificationService.markAllRead(me);
+        }
+        return Collections.singletonMap("updated", updated);
+    }
+
+    @Data
+    public static class ReadRequest {
+        private Boolean all;
+        private List<Long> ids;
+    }
+}

--- a/src/main/resources/static/css/main-nav.css
+++ b/src/main/resources/static/css/main-nav.css
@@ -46,3 +46,16 @@
 .footer-nav a.active i {
     color: var(--primary-color) !important;
 }
+
+/* ===== 전역 알림 빨간 점 (종 아이콘 우상단) ===== */
+.nav-dot {
+    position: absolute;
+    right: 6px;
+    top: 3px;
+    width: 9px;
+    height: 9px;
+    border-radius: 9999px;
+    background: #e74c3c;
+    display: none; /* JS가 inline-block으로 토글 */
+    box-shadow: 0 0 0 2px #fff; /* 아이콘 위에서 또렷하게 보이도록 */
+}

--- a/src/main/resources/templates/notification/notification.html
+++ b/src/main/resources/templates/notification/notification.html
@@ -4,7 +4,7 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8"/>
-    <!-- CSRF 메타: notification.js에서 /notification/* POST 호출 시 헤더로 첨부 -->
+    <!-- CSRF 메타: notification.js에서 /notification POST 호출 시 헤더로 첨부 -->
     <!-- [운영 메모] CSRF 메타는 Spring Security 미사용 환경에선 비어 있을 수 있음
          - /js/notification.js의 authHeaders()가 메타 존재 시 자동 첨부, 미존재 시 무시
          - 다중 탭/로그인 만료 상황을 고려해 401 응답시 재로그인 유도 처리 권장 -->
@@ -21,10 +21,10 @@
     <!--
       역할(정확한 명칭)
       - 본 템플릿은 알림센터 UI의 컨테이너이며, 실제 데이터 로딩/읽음/뱃지 갱신은 /js/notification.js가 담당
-        · 알림 목록 로딩:        POST /notification/list
-        · 선택 알림 읽음 처리:   POST /notification/read (멱등)
-        · 미읽음 카운트 갱신:    POST /notification/unread-count (배지/빨간점)
-        · 알림 행 클릭 이동:     GET  /profile/:userId
+        · 알림 목록 로딩:        POST /api/notifications/list
+        · 읽음 처리(전체/선택):   POST /notification   ← (단일 엔드포인트, suffix 금지)
+        · 미읽음 카운트 갱신:    POST /api/notifications/unread-count
+        · 알림 행 클릭 이동:     GET  /profile/{nickname}
       - 서비스워커와의 연계(클릭 라우팅)
         · service-worker.js의 'notificationclick'에서 postMessage({type:'NAVIGATE', url})를 보내면
           페이지 측에서 라우팅을 수행(알림 클릭 → 본 페이지로 진입하는 시나리오 포함)
@@ -34,8 +34,6 @@
     -->
 
     <!-- PWA: 앱 메타(아이콘/이름 등). SW 등록은 main-nav.js에서 수행 -->
-    <!-- [PWA 메모] manifest.json의 scope/start_url이 service-worker.js 스코프(/)와 정합해야
-         알림 아이콘/이름/스플래시가 일관되게 동작함. 아이콘 경로는 /icons/* 로 맞춤 권장 -->
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
 
     <!-- 페이지 스크립트: 목록 로딩/읽음 처리/뱃지 갱신 수행 -->
@@ -46,19 +44,9 @@
 <h2>Notification</h2>
 
 <!-- 알림 목록 컨테이너: notification.js가 innerHTML로 카드 목록 렌더링 -->
-<!-- [렌더/보안 메모]
-     - /js/notification.js는 서버 응답 텍스트를 innerHTML로 삽입하지 말고
-       textContent 또는 속성 세팅으로 XSS 방지(특히 actor.nickname, text).
-     - 비동기 로딩 상태: skeleton(회색 블록) 또는 '로딩 중…' 플레이스홀더 권장.
-     - 빈 목록: '새 알림이 없습니다' 빈 상태(aria-live=polite와 중복 알림 방지) 표시 권장. -->
 <div aria-live="polite" class="list" id="list"></div>
 
 <!-- 페이지 이동(이전/다음): notification.js가 상태(page/last) 갱신 -->
-<!-- [페이징 UX 메모]
-     - 첫 페이지(page===0)에서는 #prev.disabled 처리 및 aria-disabled="true" 부여.
-     - 마지막 페이지(last===true)에서는 #next.disabled 처리 및 aria-disabled="true".
-     - 현재 페이지 번호는 #page.textContent로만 표시(스크린리더를 위해 '현재 페이지 n' 라벨링 권장).
-     - 키보드 접근성: 좌/우 화살표 또는 PageUp/Down을 버튼 클릭과 동일하게 위임 가능. -->
 <div class="pager">
     <button id="prev">이전</button>
     <span id="page"></span>


### PR DESCRIPTION
### 제목
[기능] 전역 알림 배지(종아이콘 빨간 점) + 읽음 처리 단일 엔드포인트 적용

---

### 상세 설명
- 미확인 알림(unread)이 존재하는 동안 main-nav가 보이는 모든 페이지에서 종 아이콘에 빨간 점 표시
- 알림 페이지(`/notification`) 진입 시 읽음 처리는 POST `/notification` 단일 엔드포인트로 수행한다.  
  - 규칙: `/notification` 뒤에 다른 경로 세그먼트가 붙지 않는다.
  - 요청 바디 규약
    - 전체 읽음: `{}` 또는 `{ "all": true }`
    - 선택 읽음: `{ "ids": [<number>, ...] }`
  - 응답: `{"updated": <number>}` 또는 `204 No Content`
- 전역 빨간 점 표시는 카운트 조회 전용 API(현행)로 유지:
  - `POST /api/notifications/unread-count` (세션 필요)
  - 이 API는 읽음이 아닌 “조회”이므로 `/notification` 단일 규칙 대상이 아님.
- 인증 만료/오류 시 화면 오류 노출 없이 조용히 실패 처리 + 도트 숨김으로 동작.

---

### 작업 내용
- [ ] 전역 배지 앵커: `main-nav.html` 종 아이콘 내부에 `#nav-bell-dot.nav-dot` 존재 확인(미존재 시 추가)
- [ ] 전역 배지 스타일: `main-nav.css`에 `.nav-dot` 최소 스타일(8~10px, 원형, 빨간색, 종 아이콘 우상단, 기본 `display:none`)
- [ ] 카운트 연동: `main-nav.js`에서 `POST /api/notifications/unread-count` 호출
  - [ ] `credentials: 'include'` 적용, `Accept: application/json`
  - [ ] 초기 로드 / `window.focus` / `visibilitychange`에서 재조회
  - [ ] 401/HTML 응답 시 조용히 실패 처리(도트 숨김)
- [ ] 읽음 처리 단일화: `notification.js`에서 **POST `/notification`** 호출
  - [ ] 페이지 진입 시 1회 전체 읽음(`{}`) 호출
  - [ ] (선택) 개별 읽음 시 `{ "ids": [...] }` 사용 가능
  - [ ] 모든 요청에 `credentials: 'include'`
- [ ] 도트 숨김 타이밍: 알림 페이지 이탈 시 전역 도트 숨김 유지/보강  
      (pagehide / visibilitychange / beforeunload 훅)
- [ ] QA/완료 기준
  - [ ] 미읽음 > 0이면 어느 페이지에서든 도트 표시, 0이면 숨김
  - [ ] `/notification` 진입 후 읽음 처리 → 페이지를 떠날 때 도트 숨김
  - [ ] 세션 만료 상태에서 조회/읽음 호출 시 화면 오류 없이 안전 실패(도트 숨김)
  - [ ] 다중 탭: 한 탭에서 읽음 후, 다른 탭 포커스 시 도트 상태 갱신
- [ ] 문서화: README/위키에 동작 정책(표시/숨김 타이밍), 엔드포인트 규약(POST `/notification` 단일), 에러 처리 전략 간단 기록

---

### 관련 문서/레퍼런스
- 읽음 처리: POST `/notification` (단일, no trailing path)
- 카운트 조회: **POST `/api/notifications/unread-count`** (JSON, 인증)
- 보안: fetch 시 `credentials: 'include'` 필수, CSRF는 프로젝트 정책 준수
- UX 정책: “알림 페이지 **떠날 때** 전역 도트 숨김” (read-all은 진입 시 서버 상태 반영)

---
