### PR TITLE
[fix] 알림 페이지 스크롤 UX 수정 + [feat] CSS 구현

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1,3 +1,15 @@
+/* 전역: 스크롤 가능하도록 해제 */
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    background-color: #f0f2f5;
+    /* 기존 overflow: hidden → auto (또는 기본값) */
+    overflow: auto;
+}
+
 :root {
     --shadow-color: rgba(0, 0, 0, 0.1);
 }

--- a/src/main/resources/static/css/notification.css
+++ b/src/main/resources/static/css/notification.css
@@ -1,38 +1,135 @@
-/* ===== Notification list basic layout ===== */
-#page-notifications .list {
-    /* 네비게이션 바가 가리지 않도록 아래쪽에 여백 확보 */
-    padding: 8px 12px 88px; /* 마지막 줄이 footer-nav 뒤에 숨지지 않게 */
-    max-width: 360px; /* footer-nav와 동일 폭으로 중앙 정렬 */
-    margin: 0 auto;
+/* ===== Notification page styles ===== */
+
+/* 네비 높이 기본값(안전치) + 페이저 상하 대칭 간격 */
+:root {
+    --footer-height: 120px; /* JS가 실측으로 덮어씀 */
+    --pager-gap: 16px; /* 마지막 카드↔페이저 간격 = 페이저 상단 간격 */
+
+    /* 빨간 점 위치/크기/간격(프로필과 1글자 정도 떨어지도록) */
+    --dot-left: 8px; /* 카드 왼쪽에서 점까지 */
+    --dot-size: 8px; /* 점 지름 */
+    --dot-gap: 8px; /* 점과 아바타 사이 간격(≈ 1글자) */
 }
 
-/* 한 행(카드) */
-.noti-card {
+/* 이 페이지에서 전역 flex 영향 제거 + 가로 스크롤 방지 + 배경 흰색(양옆 띠 제거) */
+#page-notifications {
+    display: block;
+    width: 100%;
+    min-height: 100%;
+    overflow-x: hidden;
+    background: #fff; /* ← 전체 배경 흰색으로 통일 */
+}
+
+/* ===== 상단바 ===== */
+.noti-topbar {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    height: 48px;
     display: flex;
-    gap: 10px;
     align-items: center;
+    justify-content: center; /* 가운데 타이틀 */
+    background: #fff;
+    border-bottom: 1px solid #e9e9e9;
+}
+
+.noti-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.noti-back-btn {
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 36px;
+    height: 36px;
+    border: 0;
+    background: transparent;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    color: #333;
+}
+
+/* ===== 리스트 ===== */
+#page-notifications .list {
+    width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
+    padding: 8px 12px 0; /* ← 하단 패딩 제거: 마지막 카드와 페이저 간격은 pager의 margin-top으로만 제어 */
+    box-sizing: border-box;
+    background: #fff;
+    /* 좌우 연한 보더 제거(배경과 완전 동일하게) */
+    border-left: 0;
+    border-right: 0;
+}
+
+/* 비었을 때 */
+#page-notifications .list .empty {
+    padding: 24px 12px;
+    color: #999;
+    text-align: center;
+}
+
+/* ===== 카드 ===== */
+/* a 요소 자체를 카드로 사용 */
+.noti-card {
+    position: relative; /* 빨간 점 의사요소 위치 기준 */
+    display: flex;
+    align-items: center;
+    gap: 10px;
     padding: 12px 6px;
     border-bottom: 1px solid #eee;
     text-decoration: none;
     color: inherit;
+
+    /* 빨간 점 칼럼을 항상 예약 → 점 유무와 무관하게 정렬 고정 */
+    padding-left: calc(var(--dot-left) + var(--dot-size) + var(--dot-gap));
 }
 
-/* 미읽음 빨간 점 (좌측) */
-.noti-unread-dot {
-    width: 8px;
-    height: 8px;
+/* 링크 파란색/밑줄 제거(모든 상태) */
+a.noti-card,
+a.noti-card:link,
+a.noti-card:visited,
+a.noti-card:hover,
+a.noti-card:active {
+    color: inherit;
+    text-decoration: none;
+}
+
+/* 빨간 점: 의사요소. data-unread="true"일 때만 채워짐 */
+.noti-card::before {
+    content: "";
+    position: absolute;
+    left: var(--dot-left);
+    top: 50%;
+    transform: translateY(-50%);
+    width: var(--dot-size);
+    height: var(--dot-size);
     border-radius: 9999px;
-    background: #e74c3c;
-    flex: 0 0 8px;
+    background: transparent;
 }
 
-/* 프로필 이미지: 원형 */
-.noti-avatar {
+.noti-card[data-unread="true"]::before {
+    background: #e74c3c;
+}
+
+/* 프로필 이미지(원형, 전역 규칙 무력화) */
+#page-notifications .noti-card .noti-avatar {
     width: 42px;
     height: 42px;
     border-radius: 50%;
     object-fit: cover;
     flex: 0 0 42px;
+    display: block;
+    max-width: none;
+    max-height: none;
+    aspect-ratio: 1 / 1;
 }
 
 /* 본문 래퍼 */
@@ -40,26 +137,26 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
-    min-width: 0; /* 닉네임 길어도 줄넘김 잘 되도록 */
+    min-width: 0;
     flex: 1 1 auto;
 }
 
-/* 1줄: 닉네임 + 시간 */
+/* 1줄: 닉네임 + 시간(같은 줄, 오른쪽 끝 정렬 아님) */
 .noti-head {
     display: flex;
     align-items: baseline;
-    gap: 8px;
+    gap: 8px; /* 닉네임과 시간 사이 1~2글자 간격 */
 }
 
 .noti-nick {
-    font-weight: 600;
+    font-weight: 700;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
 .noti-time {
-    margin-left: auto; /* 같은 줄 오른쪽 끝 정렬 */
+    flex: none; /* 자동 우측 밀림 방지 */
     font-size: 12px;
     color: #999;
 }
@@ -67,16 +164,33 @@
 /* 2줄: 메시지 */
 .noti-text {
     color: #555;
-    line-height: 1.25;
+    line-height: 1.3;
     word-break: break-word;
 }
 
-/* 페이저가 네비와 겹치지 않도록 간격 확보 */
+/* ===== 페이저 ===== */
 .pager {
+    width: 100%;
     max-width: 360px;
-    margin: 12px auto 100px; /* 아래로 여유 */
+    margin: var(--pager-gap) auto calc(var(--footer-height) + var(--pager-gap));
     display: flex;
     gap: 8px;
     align-items: center;
     justify-content: center;
+    box-sizing: border-box;
+}
+
+.pager button {
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fff;
+    color: #444;
+    font-size: 14px;
+}
+
+.pager button[aria-disabled="true"],
+.pager button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }

--- a/src/main/resources/templates/notification/notification.html
+++ b/src/main/resources/templates/notification/notification.html
@@ -1,47 +1,34 @@
 <!--템플릿: 알림센터 페이지-->
-
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8"/>
     <!-- CSRF 메타: notification.js에서 /notification POST 호출 시 헤더로 첨부 -->
-    <!-- [운영 메모] CSRF 메타는 Spring Security 미사용 환경에선 비어 있을 수 있음
-         - /js/notification.js의 authHeaders()가 메타 존재 시 자동 첨부, 미존재 시 무시
-         - 다중 탭/로그인 만료 상황을 고려해 401 응답시 재로그인 유도 처리 권장 -->
     <meta name="_csrf" th:attr="content=${_csrf?.token}">
     <meta name="_csrf_header" th:attr="content=${_csrf?.headerName}">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <title>Notification</title>
+
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/main.css}">
     <link rel="stylesheet" th:href="@{/css/main-nav.css}">
     <link rel="stylesheet" th:href="@{/css/notification.css}">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 
-    <!--
-      역할(정확한 명칭)
-      - 본 템플릿은 알림센터 UI의 컨테이너이며, 실제 데이터 로딩/읽음/뱃지 갱신은 /js/notification.js가 담당
-        · 알림 목록 로딩:        POST /api/notifications/list
-        · 읽음 처리(전체/선택):   POST /notification   ← (단일 엔드포인트, suffix 금지)
-        · 미읽음 카운트 갱신:    POST /api/notifications/unread-count
-        · 알림 행 클릭 이동:     GET  /profile/{nickname}
-      - 서비스워커와의 연계(클릭 라우팅)
-        · service-worker.js의 'notificationclick'에서 postMessage({type:'NAVIGATE', url})를 보내면
-          페이지 측에서 라우팅을 수행(알림 클릭 → 본 페이지로 진입하는 시나리오 포함)
-
-      [SW 연계 주의]
-      - 동일 URL 재방문 시 중복 이동 방지: 현재 location.pathname과 동등하면 스크롤/포커스만 조정.
-    -->
-
-    <!-- PWA: 앱 메타(아이콘/이름 등). SW 등록은 main-nav.js에서 수행 -->
+    <!-- PWA -->
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
-
     <!-- 페이지 스크립트: 목록 로딩/읽음 처리/뱃지 갱신 수행 -->
     <script defer th:src="@{/js/bundle.js}"></script>
 </head>
 <body id="page-notifications">
-<!-- 페이지 타이틀(정적) -->
-<h2>Notification</h2>
+
+<!-- 상단바: 좌측 뒤로가기 + 가운데 타이틀 -->
+<header class="noti-topbar">
+    <button aria-label="뒤로가기" class="noti-back-btn" id="noti-back" type="button">
+        <i aria-hidden="true" class="fas fa-chevron-left"></i>
+    </button>
+    <h2 class="noti-title">Notification</h2>
+</header>
 
 <!-- 알림 목록 컨테이너: notification.js가 innerHTML로 카드 목록 렌더링 -->
 <div aria-live="polite" class="list" id="list"></div>


### PR DESCRIPTION
## 구현 내용 요약
- 알림 페이지 상단바 구현: 좌측 뒤로가기 버튼 + 중앙 정렬 타이틀(“Notification”)
- 스크롤/레이아웃 수정: 마지막 항목·페이저가 하단 고정 네비(footer-nav)에 가려지지 않도록 여백 계산 안정화
- 페이저와 하단바 간격 대칭화: 기기별 네비 높이 실측값을 CSS 변수로 반영하여 안정적인 간격 유지
- 미확인 알림 빨간 점 정렬 개선: 의사요소(::before) + 고정 칼럼 예약으로 점 유무와 무관하게 카드 정렬 고정
- 링크/아바타 시각 규칙 보정: 파란색/밑줄 제거, 프로필 이미지를 항상 원형 유지
- 배경 통일: 페이지/리스트 배경을 흰색(#fff)으로 통일해 양옆 회색 띠 제거
- 도트 표시 정책 정교화: **페이지 입장 시 도트 유지**, **페이저로 내부 페이지 이동 시에만 도트 숨김**, 페이지 이탈 시 재확인
- 닉네임 옆 시간 표시: 같은 줄에서 1~2글자 간격으로 표기(우측 정렬 아님)

※ 완료 기준 충족:
- 10개 페이지에서 마지막 항목과 페이저가 항상 보임
- 전역 스크롤 정상(가로 스크롤 없음), 콘텐츠 잘림 없음

---

## 관련 이슈
Closes #101  
Closes #31

---

## 작업 상세 내역
- **HTML (notification.html)**
  - 상단바 마크업 추가: `<header class="noti-topbar">`에 좌측 `#noti-back` 버튼, 중앙 `.noti-title`
  - 기존 목록(.list) / 페이저(.pager) / 하단 네비 구조는 유지

- **CSS (notification.css)**
  - 전역 변수 도입: `--footer-height`, `--pager-gap`, `--dot-left`, `--dot-size`, `--dot-gap`
  - 페이지 배경을 `#fff`로 통일, `.list` 좌우 보더 제거 → 양옆 회색 띠 제거
  - `.list` 하단 패딩 제거, 페이저의 `margin-top`과 `margin-bottom(calc(var(--footer-height) + var(--pager-gap)))`로 간격 일원화
  - `.noti-card`에 빨간 점 전용 칼럼 예약(`padding-left: calc(var(--dot-left) + var(--dot-size) + var(--dot-gap))`)
  - 빨간 점을 의사요소로 처리: `.noti-card::before` + `[data-unread="true"]`에서만 채움
  - 링크 상태(visited/hover 등) 전부 밑줄/파란색 제거, 아바타 원형 강제(전역 img 규칙 무력화)
  - 닉네임 옆 시간 간격 `gap: 8px`로 고정(우측 정렬 제거)

- **JS (notification.js)**
  - 뒤로가기 버튼 클릭 시 `history.back()`, 실패 시 `/forumMain` 폴백
  - `.main-nav-bar`의 실제 높이를 측정해 `--footer-height`에 반영(`syncFooterHeightVar`)
  - 알림 렌더 시 `row.dataset.unread = String(!read)`로 점 표시만 토글(DOM 추가 없이 정렬 고정)
  - **도트 정책 변경**: 페이지 입장/초기 렌더/전체 읽음 처리 직후에는 도트 유지, **Prev/Next 클릭 시에만** `setNavDotVisible(false)` 호출
  - 페이지 이탈 시(`pagehide`/`beforeunload`) 도트 숨김 보장

---

## from to
<feature/notification-scroll> -> <main>

---
