### PR TITLE
[feature] : 지역 검색 페이지 UI/UX 개선 및 CSS 스타일링

### DIFF
--- a/src/main/js/pages/forum-area-search.js
+++ b/src/main/js/pages/forum-area-search.js
@@ -2,6 +2,8 @@
 export function initForumAreaSearch() {
     const searchInput = $('#location-search');
     const resultsList = $('#search-results');
+    const backButton = $('.back-button'); // 뒤로가기 버튼 요소
+
     let availableLocations = []; // 지역 목록을 저장할 빈 배열
 
     // 1. 페이지 로드 시 백엔드에서 지역 목록을 가져오는 함수
@@ -98,5 +100,10 @@ export function initForumAreaSearch() {
                 alert('네트워크 오류가 발생했습니다.');
             }
         });
+    });
+
+    // 뒤로가기 버튼 클릭 시 이전 페이지로 이동
+    backButton.on('click', function () {
+        window.history.back();
     });
 }

--- a/src/main/resources/static/css/forum-area-search.css
+++ b/src/main/resources/static/css/forum-area-search.css
@@ -1,0 +1,90 @@
+#page-forum-area-search #app-container {
+    padding-top: 0;
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+/* 검색 페이지 헤더 */
+.search-header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    padding: 15px 0; /* 좌우 패딩 제거 */
+    border-bottom: 1px solid #ddd;
+}
+
+.back-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 5px;
+    display: flex;
+    align-items: center;
+    color: #333;
+}
+
+.back-button svg {
+    width: 24px;
+    height: 24px;
+}
+
+.header-title {
+    margin: 0;
+    margin-left: 20px;
+    font-size: 1.2em;
+    color: #333;
+    font-weight: bold;
+}
+
+/* 검색바 */
+.search-bar {
+    width: 100%; /* 부모 컨테이너의 너비를 100%로 채움 */
+    margin: 20px 0;
+}
+
+.input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    border: 1px solid #ddd; /* 회색 테두리 */
+    border-radius: 8px; /* 뾰족하지 않은 직사각형 */
+    padding: 10px 15px; /* 내부 여백 */
+    background-color: #f0f2f5; /* 안쪽 배경을 회색으로 설정 */
+}
+
+.map-icon {
+    width: 20px;
+    height: 20px;
+    margin-right: 10px;
+    color: #888;
+}
+
+.search-input {
+    flex-grow: 1; /* 남은 공간을 모두 채움 */
+    border: none;
+    background-color: transparent;
+    font-size: 1em;
+    outline: none;
+    padding: 0;
+}
+
+/* 검색 결과 목록 */
+.search-results {
+    list-style: none; /* 기본 리스트 점 제거 */
+    padding: 0;
+    margin: 0; /* 기본 마진 제거 */
+    width: 100%;
+}
+
+.search-results li {
+    padding: 15px; /* 상하좌우 여백을 균일하게 설정 */
+    cursor: pointer;
+    font-size: 1em;
+    color: #333;
+    transition: background-color 0.2s ease;
+}
+
+.search-results li:hover {
+    background-color: #f8f9fa; /* 호버 시 배경색 변경 */
+}

--- a/src/main/resources/templates/forum/forum-area-search.html
+++ b/src/main/resources/templates/forum/forum-area-search.html
@@ -5,16 +5,35 @@
     <title>Forum Area Search</title>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
+    <link rel="stylesheet" th:href="@{/css/index.css}">
+    <link rel="stylesheet" th:href="@{/css/forum-area-search.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
 </head>
 <body id="page-forum-area-search">
-<div class="search-container">
-    <h1>지역 검색</h1>
-    <div class="search-bar">
-        <input class="search-input" id="location-search" placeholder="지역을 검색하세요..." type="text">
+<div id="app-container">
+    <div class="search-header">
+        <button class="back-button">
+            <svg class="feather feather-arrow-left" fill="none" height="24" stroke="currentColor" stroke-linecap="round"
+                 stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24"
+                 xmlns="http://www.w3.org/2000/svg">
+                <line x1="19" x2="5" y1="12" y2="12"></line>
+                <polyline points="12 19 5 12 12 5"></polyline>
+            </svg>
+        </button>
+        <h2 class="header-title">지역 검색</h2>
     </div>
-    <ul class="search-results" id="search-results">
-    </ul>
+    <div class="search-bar">
+        <div class="input-wrapper">
+            <svg class="map-icon" fill="none" stroke="currentColor" stroke-linecap="round"
+                 stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+                <polyline points="2 17 12 22 22 17"></polyline>
+                <polyline points="2 12 12 17 22 12"></polyline>
+            </svg>
+            <input class="search-input" id="location-search" placeholder="지역을 선택하세요..." type="text">
+        </div>
+    </div>
+    <ul class="search-results" id="search-results"></ul>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## 구현 내용 요약
- 지역 검색 페이지 UI/UX 디자인 개선
- 검색창 및 검색 결과 목록 스타일링
- 뒤로가기 버튼 기능 추가

---

## 관련 이슈
Closes #110 

---

## 작업 상세 내역
- <div class="search-header">를 추가하여 뒤로가기 버튼과 제목을 구현.
- 검색창과 결과 목록을 감싸는 search-container를 제거하고, app-container 내에 직접 배치하여 흰색 배경 제거.
- 검색 입력창 안에 지도 아이콘을 추가하기 위해 input 태그를 <div class="input-wrapper">로 감싸도록 수정.
- forum-area-search.css 파일에 .search-header, .search-bar, .search-input, .search-results 등 페이지 요소에 대한 스타일을 새로 정의.
- 컨테이너 밖으로 튀어나오는 문제를 해결하기 위해 box-sizing: border-box를 사용하고, app-container에 패딩을 일괄 적용.
- 검색 입력창의 테두리를 없애고 배경색을 회색으로 변경.
- 검색 결과 목록의 점을 제거하고 패딩을 조절하여 깔끔한 리스트 형태로 수정.
- 뒤로가기 버튼 클릭 시 window.history.back() 함수를 호출하여 이전 페이지로 이동하는 기능 추가.

---

## from to
<feature/area-search-css> -> <develop>

---