### PR TITLE
[feat]: 게시글 작성자 프로필 페이지 링크 추가

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/dto/ForumPostListResponseDto.java
@@ -17,6 +17,7 @@ public class ForumPostListResponseDto {
     private String location;
     private String contentsText;
     private String writerNickname;
+    private Long writerId;
     private List<String> imageUrls;
     private String musicApiUrl;
     private String writerProfilePhotoUrl;
@@ -44,6 +45,7 @@ public class ForumPostListResponseDto {
         this.location = forumEntity.getLocation().getAddress();
         this.contentsText = forumEntity.getContentsText();
         this.writerNickname = forumEntity.getWriter().getNickname();
+        this.writerId = forumEntity.getWriter().getId();
         this.imageUrls = forumEntity.getImages().stream()
                 .map(ForumImageEntity::getImgUrl)
                 .collect(Collectors.toList());

--- a/src/main/js/pages/main.js
+++ b/src/main/js/pages/main.js
@@ -408,15 +408,17 @@ export function initMain() {
                 <button class="post-options-button" data-forum-id="${post.id}">...</button>
             </div>
         ` : '';
-        const likeButtonClass = post.liked ? 'like-button liked' : 'like-button';
-        const heartIcon = post.liked ? '♥' : '♡'; // 변경: 유니코드 하트 문자 사용
+        const likeButtonClass = post.isLiked ? 'like-button liked' : 'like-button';
+        const heartIcon = post.isLiked ? '♥' : '♡';
         return `
            <div class="post-card" data-post-id="${post.id}">
                 <div class="post-header">
                     <div class="post-author">
-                        <img alt="${post.writerNickname}" src="${post.writerProfilePhotoUrl}" class="profile-img">
+                        <a href="/profile/${post.writerNickname}" class="profile-link">
+                            <img alt="${post.writerNickname}" src="${post.writerProfilePhotoUrl}" class="profile-img">
+                        </a>
                         <div class="post-author-info">
-                            <div class="name">${post.writerNickname}</div>
+                             <a href="/profile/${post.writerNickname}" class="profile-link name">${post.writerNickname}</a>
                             <div class="time">${timeAgoText}</div>
                         </div>
                     </div>

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -597,3 +597,33 @@ html, body {
     visibility: visible;
     display: flex;
 }
+
+.post-card .post-author .profile-link {
+    text-decoration: none; /* 링크 밑줄 제거 */
+    color: inherit; /* 기본 글자색 상속 (파란색 방지) */
+    cursor: pointer; /* 마우스 오버 시 손가락 모양으로 변경 */
+    display: flex; /* 이미지는 옆으로 오도록 */
+    align-items: center; /* 세로 중앙 정렬 */
+}
+
+/* 닉네임 부분에 대한 추가적인 스타일 조정 (필요한 경우) */
+.post-card .post-author .profile-link .name {
+    /* 닉네임의 특정 스타일이 필요한 경우 여기에 추가 */
+    /* 예: font-weight: bold; */
+    margin-left: 8px; /* 프로필 사진과의 간격 */
+}
+
+/* 프로필 사진 스타일 (기존과 동일하게 유지) */
+.post-card .post-author .profile-img {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+/* 호버 시 배경색 변경과 같은 효과가 필요 없다면 아래 코드는 제거 */
+.post-card .post-author .profile-link:hover {
+    background-color: transparent; /* 호버 시 배경색 변경 없음 */
+    /* 필요하다면 여기에 아주 미세한 변화를 줄 수 있습니다. */
+    /* 예: opacity: 0.8; */
+}


### PR DESCRIPTION
## 구현 내용 요약
- 메인 페이지의 게시글 목록에 있는 작성자 프로필 사진과 닉네임을 클릭하면 해당 사용자의 프로필 페이지로 이동하는 기능을 구현했습니다.
- 사용자 경험을 향상시키고, 커뮤니티 내 사용자 간의 상호작용을 활성화하는 것을 목표로 합니다.

---

## 관련 이슈
Closes #113 

---

## 작업 상세 내역
- ForumPostListResponseDto 수정: 게시글 목록 API 응답에 writerId 필드를 추가
- createPostHtml 함수를 수정하여 작성자의 프로필 이미지와 닉네임을 <a href="/profile/writerNickname"> 태그로 묶
- 게시글의 동적 생성 시 프로필 링크가 올바르게 작동하도록 구현
- 링크의 기본 스타일인 밑줄과 파란색 글씨를 제거하여 기존 디자인과 자연스럽게 어울리도록 text-decoration: none 및 color: inherit 속성을 사용
- 마우스를 올렸을 때 클릭 가능한 요소임을 알리기 위해 cursor: pointer 속성을 추가

---

## from to
<feature/user-profile-link> -> <develop>

---