### PR TITLE
[feat] : 이미지 편집 및 비율 조정 기능 추가

### DIFF
--- a/src/main/resources/static/css/forum-write.css
+++ b/src/main/resources/static/css/forum-write.css
@@ -218,3 +218,87 @@
     font-size: 0.9em;
     line-height: 1.4;
 }
+
+/* 이미지 편집기 팝업 관련 CSS */
+.popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.9);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.popup-overlay.show {
+    display: flex;
+}
+
+.popup-content {
+    display: flex;
+    flex-direction: column;
+    width: 360px;
+    height: 780px;
+    background-color: #000;
+    color: #fff;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.popup-header {
+    display: flex;
+    justify-content: flex-start;
+    padding-bottom: 15px;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 2rem;
+    cursor: pointer;
+}
+
+.editor-main {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
+}
+
+/* cropper.js를 위한 이미지 컨테이너 CSS */
+.image-cropper-container {
+    width: 100%;
+    padding-bottom: 133.33%;
+    position: relative;
+    overflow: hidden;
+    background-color: #111;
+}
+
+/* cropper.js가 사용하는 img 태그는 건드리지 않음 */
+.image-cropper-container img {
+    display: block;
+    max-width: 100%;
+}
+
+.popup-footer {
+    padding-top: 15px;
+    text-align: center;
+}
+
+.editor-btn {
+    background-color: #fff;
+    color: #000;
+    border: none;
+    border-radius: 25px;
+    padding: 10px 30px;
+    font-weight: bold;
+    font-size: 1rem;
+    cursor: pointer;
+}

--- a/src/main/resources/templates/forum/forum-write.html
+++ b/src/main/resources/templates/forum/forum-write.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" th:href="@{/css/forum-write.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
 </head>
 <body id="page-forum-write">
 <div id="app-container">
@@ -51,6 +53,22 @@
 
 <div class="toast-container" id="toast">
     <span class="toast-message"></span>
+</div>
+
+<div class="popup-overlay" id="image-editor-overlay">
+    <div class="popup-content">
+        <div class="popup-header">
+            <button class="close-btn" id="editor-close-btn">&times;</button>
+        </div>
+        <div class="editor-main">
+            <div class="image-cropper-container" id="image-cropper-container">
+                <img alt="Image to crop" id="image-to-crop">
+            </div>
+        </div>
+        <div class="popup-footer">
+            <button class="editor-btn" id="editor-done-btn">다음</button>
+        </div>
+    </div>
 </div>
 
 </body>


### PR DESCRIPTION
## 구현 내용 요약
- Cropper.js 라이브러리를 사용하여 이미지 편집 기능 구현
- 3:4 비율 (세로:가로)에 맞춰 이미지 크롭 및 미리보기 제공
- 터치 및 마우스 드래그를 통한 이미지 위치 조정 및 확대/축소 기능 추가
- 
---

## 관련 이슈
Closes #116 

---

## 작업 상세 내역
- forum-write.html에 Cropper.js CDN 링크 추가 및 슬라이더 UI 제거
- forum-write.js에 Cropper.js 인스턴스를 생성하고 관리하는 로직 구현
- 이미지 선택 시 Cropper.js를 활성화하고, '다음' 버튼 클릭 시 크롭된 이미지 데이터를 가져오도록 로직 수정
- forum-write.css에서 이미지 편집기 컨테이너 비율을 3:4로 조정하고 기존 슬라이더 스타일 삭제
- 팝업 닫기 시 Cropper.js 인스턴스를 정상적으로 파기하는 로직 추가

---

## from to
<feature/image-editor-cropper> -> <develop>

---