### PR TITLE
[기능] Forum 댓글 알림(작성자 대상) — 앱(FCM) 우선 + 웹 푸시 #128

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
+++ b/src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
@@ -1,15 +1,20 @@
+// src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
 package io.github.nokasegu.post_here.common.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * FirebaseConfig
@@ -42,13 +47,23 @@ public class FirebaseConfig {
             }
 
             String path = credentialsPath;
+
+            // [수정] file:, classpath: 모두 지원
+            InputStream serviceAccountStream;
             if (path.startsWith("file:")) {
-                path = path.substring("file:".length());
+                String real = path.substring("file:".length());
+                serviceAccountStream = new FileInputStream(real);
+            } else if (path.startsWith("classpath:")) {
+                String cp = path.substring("classpath:".length());
+                serviceAccountStream = new ClassPathResource(cp).getInputStream();
+            } else {
+                // 스킴이 없으면 파일 경로로 간주
+                serviceAccountStream = new FileInputStream(path);
             }
 
-            try (FileInputStream serviceAccount = new FileInputStream(path)) {
+            try (InputStream in = serviceAccountStream) {
                 FirebaseOptions options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                        .setCredentials(GoogleCredentials.fromStream(in))
                         .setProjectId(projectId)
                         .build();
 
@@ -58,5 +73,17 @@ public class FirebaseConfig {
         } catch (IOException e) {
             log.error("Failed to initialize FirebaseApp", e);
         }
+    }
+
+    // [추가] FcmSenderService에서 주입받을 FirebaseMessaging 빈 정의
+    // - init()에서 FirebaseApp이 초기화되므로 여기서는 기본 인스턴스를 반환
+    // - 만약 외부에서 먼저 초기화되었다면 기본 인스턴스를 재사용
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        if (FirebaseApp.getApps().isEmpty()) {
+            // [추가 설명] 이론상 @PostConstruct가 먼저 실행되지만, 혹시를 대비해 보호 로직
+            init();
+        }
+        return FirebaseMessaging.getInstance();
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
+++ b/src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
@@ -1,89 +1,144 @@
 // src/main/java/io/github/nokasegu/post_here/common/config/FirebaseConfig.java
 package io.github.nokasegu.post_here.common.config;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
-import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.StringUtils;
 
-import java.io.FileInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
-/**
- * FirebaseConfig
- * <p>
- * 역할
- * - 서버 기동 시 FirebaseApp을 1회 초기화하여 FCM HTTP v1 사용 가능하게 함.
- * <p>
- * 설정
- * - application-secret.yml
- * firebase:
- * credentials: "file:/var/config/firebase-service-account.json"
- * project-id:  "YOUR_FIREBASE_PROJECT_ID"
- */
-@Slf4j
 @Configuration
+@RequiredArgsConstructor
+@Slf4j
 public class FirebaseConfig {
 
-    @Value("${firebase.credentials}")
-    private String credentialsPath; // file:/... 경로 권장
+    private final ResourceLoader resourceLoader;
 
-    @Value("${firebase.project-id}")
-    private String projectId;
+    // [변경 이유]
+    // - yml의 키와 정확히 일치하도록 @Value 사용
+    //   application-secret.yml 예시:
+    //   firebase:
+    //     credentials: "file:C:/Users/user/secrets/firebase-service-account.json"
+    //     project-id: "posthere-52fe8"
+    //
+    // - 'project-id'는 하이픈 표기로 읽습니다(여기서도 동일 키 사용).
+    @Value("${firebase.credentials:#{null}}")
+    private String firebaseCredentialsPath;
 
-    @PostConstruct
-    public void init() {
-        try {
-            if (!FirebaseApp.getApps().isEmpty()) {
-                log.info("FirebaseApp already initialized. Skipping.");
-                return;
+    @Value("${firebase.project-id:#{null}}")
+    private String firebaseProjectId;
+
+    /**
+     * FirebaseApp 생성
+     * <p>
+     * [핵심 변경]
+     * 1) credentials 경로가 주어졌으면 해당 JSON을 읽어 GoogleCredentials 생성
+     * 2) projectId는 우선순위: (프로퍼티) firebase.project-id → (JSON) service account의 project_id
+     * 3) projectId가 최종적으로 비어있으면 명시적 예외 + 가이드
+     * 4) 이미 FirebaseApp이 초기화돼 있으면 재사용
+     */
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        GoogleCredentials credentials;
+        String projectIdResolved = null;
+        String projectIdSource = "unset";
+        String credsSource = "unset";
+
+        // 1) Credentials 로딩
+        if (StringUtils.hasText(firebaseCredentialsPath)) {
+            Resource resource = resourceLoader.getResource(firebaseCredentialsPath);
+            if (!resource.exists()) {
+                throw new IllegalStateException("[Firebase] Service account file not found: " + firebaseCredentialsPath);
             }
 
-            String path = credentialsPath;
-
-            // [수정] file:, classpath: 모두 지원
-            InputStream serviceAccountStream;
-            if (path.startsWith("file:")) {
-                String real = path.substring("file:".length());
-                serviceAccountStream = new FileInputStream(real);
-            } else if (path.startsWith("classpath:")) {
-                String cp = path.substring("classpath:".length());
-                serviceAccountStream = new ClassPathResource(cp).getInputStream();
-            } else {
-                // 스킴이 없으면 파일 경로로 간주
-                serviceAccountStream = new FileInputStream(path);
+            byte[] jsonBytes;
+            try (InputStream in = resource.getInputStream()) {
+                jsonBytes = in.readAllBytes();
             }
 
-            try (InputStream in = serviceAccountStream) {
-                FirebaseOptions options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(in))
-                        .setProjectId(projectId)
-                        .build();
+            credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonBytes));
+            credsSource = resource.getDescription();
 
-                FirebaseApp.initializeApp(options);
-                log.info("FirebaseApp initialized (projectId={})", projectId);
+            // 2) service account JSON에서 project_id를 직접 파싱(프로퍼티가 비어있을 때만 사용)
+            if (!StringUtils.hasText(firebaseProjectId)) {
+                try {
+                    Map<String, Object> json = new ObjectMapper().readValue(
+                            jsonBytes, new TypeReference<Map<String, Object>>() {
+                            });
+                    Object pid = json.get("project_id");
+                    if (pid != null && StringUtils.hasText(pid.toString())) {
+                        projectIdResolved = pid.toString().trim();
+                        projectIdSource = "service-account";
+                    }
+                } catch (Exception e) {
+                    log.warn("[Firebase] Unable to parse 'project_id' from service account JSON: {}", e.toString());
+                }
             }
-        } catch (IOException e) {
-            log.error("Failed to initialize FirebaseApp", e);
+        } else {
+            // credentials 경로가 없으면 ADC 시도(개발용/CI 등)
+            credentials = GoogleCredentials.getApplicationDefault();
+            credsSource = "ApplicationDefaultCredentials";
         }
+
+        // 3) 프로퍼티가 있으면 최우선
+        if (StringUtils.hasText(firebaseProjectId)) {
+            projectIdResolved = firebaseProjectId.trim();
+            projectIdSource = "property(firebase.project-id)";
+        }
+
+        if (!StringUtils.hasText(projectIdResolved)) {
+            // [중요] v1 API는 projectId 필요 → 명확한 가이드 메시지
+            throw new IllegalStateException("""
+                    [Firebase] Project ID is missing.
+                    - Set 'firebase.project-id' in application-secret.yml (and import the file),
+                      or use a service account JSON that contains 'project_id'.""");
+        }
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(credentials)
+                .setProjectId(projectIdResolved)
+                .build();
+
+        // 이미 초기화된 인스턴스가 있으면 재사용
+        FirebaseApp app;
+        try {
+            app = FirebaseApp.initializeApp(options);
+            log.info("[Firebase] Admin SDK initialized. appName={}, projectId={}, creds={}",
+                    app.getName(), projectIdResolved, credsSource);
+            log.info("[Firebase] projectId source={}, credentials source={}", projectIdSource, credsSource);
+        } catch (IllegalStateException already) {
+            app = FirebaseApp.getInstance();
+            log.info("[Firebase] Reusing existing FirebaseApp. appName={}, projectId={}",
+                    app.getName(), app.getOptions().getProjectId());
+        }
+
+        return app;
     }
 
-    // [추가] FcmSenderService에서 주입받을 FirebaseMessaging 빈 정의
-    // - init()에서 FirebaseApp이 초기화되므로 여기서는 기본 인스턴스를 반환
-    // - 만약 외부에서 먼저 초기화되었다면 기본 인스턴스를 재사용
+    /**
+     * FirebaseMessaging 생성
+     * <p>
+     * [추가 로그]
+     * - init 완료 로그를 명확히 찍어 디버깅 편의↑
+     */
     @Bean
-    public FirebaseMessaging firebaseMessaging() {
-        if (FirebaseApp.getApps().isEmpty()) {
-            // [추가 설명] 이론상 @PostConstruct가 먼저 실행되지만, 혹시를 대비해 보호 로직
-            init();
-        }
-        return FirebaseMessaging.getInstance();
+    public FirebaseMessaging firebaseMessaging(FirebaseApp app) {
+        FirebaseMessaging messaging = FirebaseMessaging.getInstance(app);
+        log.info("[Firebase] FirebaseMessaging ready. projectId={}", app.getOptions().getProjectId());
+        return messaging;
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumCommentRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/repository/ForumCommentRepository.java
@@ -1,10 +1,14 @@
+// src/main/java/io/github/nokasegu/post_here/forum/repository/ForumCommentRepository.java
 package io.github.nokasegu.post_here.forum.repository;
 
 import io.github.nokasegu.post_here.forum.domain.ForumCommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ForumCommentRepository extends JpaRepository<ForumCommentEntity, Long> {
@@ -15,9 +19,21 @@ public interface ForumCommentRepository extends JpaRepository<ForumCommentEntity
      * @param forumId 포럼 게시글의 ID
      * @return 댓글 엔티티 리스트
      */
-    public List<ForumCommentEntity> findAllByForumIdOrderByCreatedAtAsc(Long forumId);
+    List<ForumCommentEntity> findAllByForumIdOrderByCreatedAtAsc(Long forumId);
 
     // 특정 게시글의 댓글 총 개수를 조회하는 메서드 추가
     int countByForumId(Long forumId);
 
+    // ===================== [신규] REQUIRES_NEW 안전용 fetch-join =====================
+    // - REQUIRES_NEW 트랜잭션에서 넘겨받은 detached 엔티티의 지연로딩 접근으로 인한
+    //   LazyInitializationException을 피하기 위해, 필요한 연관을 fetch-join으로 미리 로딩한다.
+    @Query("""
+            select c
+              from ForumCommentEntity c
+              join fetch c.writer cw
+              join fetch c.forum f
+              join fetch f.writer fw
+             where c.id = :id
+            """)
+    Optional<ForumCommentEntity> findByIdWithWriterAndForumWriter(@Param("id") Long id);
 }

--- a/src/main/java/io/github/nokasegu/post_here/forum/service/ForumCommentService.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/service/ForumCommentService.java
@@ -1,3 +1,4 @@
+// src/main/java/io/github/nokasegu/post_here/forum/service/ForumCommentService.java
 package io.github.nokasegu.post_here.forum.service;
 
 import io.github.nokasegu.post_here.forum.domain.ForumCommentEntity;
@@ -6,11 +7,15 @@ import io.github.nokasegu.post_here.forum.dto.ForumCommentRequestDto;
 import io.github.nokasegu.post_here.forum.dto.ForumCommentResponseDto;
 import io.github.nokasegu.post_here.forum.repository.ForumCommentRepository;
 import io.github.nokasegu.post_here.forum.repository.ForumRepository;
+import io.github.nokasegu.post_here.notification.service.NotificationService;
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,11 +23,18 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j // [추가] 로깅을 위해
 public class ForumCommentService {
 
     private final ForumCommentRepository forumCommentRepository;
     private final UserInfoRepository userInfoRepository;
     private final ForumRepository forumRepository; // 게시글을 찾기 위해 필요
+
+    // =================== [중요 변경] 이벤트 퍼블리셔 제거 → 서비스 직접 호출 ===================
+    // 기존: ApplicationEventPublisher + CommentCreatedEvent
+    // 변경: 트랜잭션 "커밋 이후(afterCommit)"에 NotificationService 호출
+    private final NotificationService notificationService;
+    // =====================================================================================
 
     /**
      * 특정 게시글의 모든 댓글을 조회합니다.
@@ -51,7 +63,6 @@ public class ForumCommentService {
                 .collect(Collectors.toList());
     }
 
-
     /**
      * 댓글을 생성합니다.
      */
@@ -72,6 +83,33 @@ public class ForumCommentService {
         // 댓글 저장
         ForumCommentEntity savedComment = forumCommentRepository.save(newComment);
 
+        // =================== [중요 변경] 알림은 "커밋 이후"에 실행 ===================
+        // - 동일 트랜잭션 내부에서 REQUIRES_NEW로 재조회하면 미커밋이라 조회 실패 가능 → afterCommit 사용
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    try {
+                        // [수정] ID가 아닌 엔티티 자체를 전달 (NotificationService 시그니처와 일치)
+                        notificationService.createCommentAndPush(savedComment); // REQUIRES_NEW + 안전 재조회
+                    } catch (Exception e) {
+                        log.warn("[NOTI] afterCommit send failed commentId={} err={}",
+                                savedComment.getId(), e.toString(), e);
+                    }
+                }
+            });
+        } else {
+            // 트랜잭션 동기화가 없는 경우(드물게) 즉시 시도
+            try {
+                // [수정] ID가 아닌 엔티티 자체를 전달
+                notificationService.createCommentAndPush(savedComment);
+            } catch (Exception e) {
+                log.warn("[NOTI] immediate send failed commentId={} err={}",
+                        savedComment.getId(), e.toString(), e);
+            }
+        }
+        // ========================================================================
+
         return new ForumCommentResponseDto(savedComment, true);
     }
 
@@ -91,7 +129,6 @@ public class ForumCommentService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         // 3. 댓글 작성자 권한 확인
-        // 댓글의 작성자 ID와 현재 사용자 ID를 비교하여, 동일한 경우에만 삭제를 허용
         if (!comment.getWriter().getId().equals(currentUser.getId())) {
             throw new IllegalArgumentException("해당 댓글을 삭제할 권한이 없습니다.");
         }

--- a/src/main/java/io/github/nokasegu/post_here/notification/controller/PushDebugController.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/controller/PushDebugController.java
@@ -1,0 +1,97 @@
+package io.github.nokasegu.post_here.notification.controller;
+
+import com.google.firebase.FirebaseApp;
+import io.github.nokasegu.post_here.notification.service.FcmSenderService;
+import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
+import io.github.nokasegu.post_here.userInfo.repository.UserInfoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 디버그 전용 REST 컨트롤러
+ * - 브라우저만으로 FCM 환경/토큰/테스트 발송을 확인하기 위한 임시 엔드포인트
+ * - 운영 배포 시에는 SecurityConfig로 관리자만 접근 허용하거나 비활성화하세요.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/push/debug")
+@RequiredArgsConstructor
+public class PushDebugController {
+
+    private final UserInfoRepository userRepo;
+    private final FcmSenderService fcmSenderService;
+
+    /**
+     * 환경 점검: FirebaseApp 초기화/프로젝트 정보를 노출
+     * GET /api/push/debug/env
+     */
+    @GetMapping("/env")
+    public Map<String, Object> env() {
+        Map<String, Object> out = new HashMap<>();
+        out.put("firebaseApps", FirebaseApp.getApps().stream().map(FirebaseApp::getName).toList());
+        out.put("defaultAppExists", !FirebaseApp.getApps().isEmpty());
+        return out;
+    }
+
+    /**
+     * 내 FCM 토큰 확인
+     * GET /api/push/debug/my-token
+     */
+    @GetMapping("/my-token")
+    public ResponseEntity<?> myToken(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "로그인 필요"));
+        }
+        UserInfoEntity me = userRepo.findByEmail(principal.getName()).orElse(null);
+        if (me == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "사용자 없음"));
+        }
+        String token = me.getFcmToken(); // A안: user_info.fcm_token 단일 컬럼 사용
+        return ResponseEntity.ok(Map.of(
+                "userId", me.getId(),
+                "email", me.getEmail(),
+                "tokenHead", token != null ? token.substring(0, Math.min(12, token.length())) : null,
+                "token", token
+        ));
+    }
+
+    /**
+     * 단건 테스트 발송(나에게)
+     * GET /api/push/debug/test-send
+     * - user_info.fcm_token 으로 "테스트" 알림을 보냅니다.
+     */
+    @GetMapping("/test-send")
+    public ResponseEntity<?> testSend(Principal principal) {
+        if (principal == null || principal.getName() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "로그인 필요"));
+        }
+        UserInfoEntity me = userRepo.findByEmail(principal.getName()).orElse(null);
+        if (me == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "사용자 없음"));
+        }
+        String token = me.getFcmToken();
+        if (!StringUtils.hasText(token)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "내 user_info.fcm_token 이 비어있음"));
+        }
+        try {
+            String id = fcmSenderService.sendToToken(token, "테스트", "디버그 발송");
+            return ResponseEntity.ok(Map.of("messageId", id));
+        } catch (RuntimeException e) {
+            // 내부적으로 FirebaseMessagingException을 감싸서 던지므로 메시지와 원인도 같이 반환
+            Throwable cause = e.getCause();
+            String msg = cause != null ? cause.toString() : e.toString();
+            log.error("[DEBUG] test-send failed: {}", msg, e);
+            return ResponseEntity.status(500).body(Map.of("error", "FCM send failed", "detail", msg));
+        }
+    }
+}

--- a/src/main/java/io/github/nokasegu/post_here/notification/controller/PushSubscriptionController.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/controller/PushSubscriptionController.java
@@ -34,13 +34,14 @@ public class PushSubscriptionController {
     public void subscribe(Principal principal, @RequestBody PushSubscribeRequestDto body) {
         UserInfoEntity me = resolveUser(principal);
 
-        pushRepo.findByEndpoint(body.getEndpoint()).ifPresentOrElse(existing -> {
-            // [수정] setter 없으면 엔티티에 @Setter 추가 필요
-            existing.setUser(me);
+        // [변경] user + endpoint 기준으로 조회/업서트
+        pushRepo.findByUserAndEndpoint(me, body.getEndpoint()).ifPresentOrElse(existing -> {
+            // 이미 해당 user+endpoint 구독 있으면 갱신
             existing.setP256dh(body.getKeys().getP256dh());
             existing.setAuth(body.getKeys().getAuth());
             pushRepo.save(existing);
         }, () -> {
+            // 없으면 새로 저장
             pushRepo.save(
                     PushSubscriptionEntity.builder()
                             .user(me)

--- a/src/main/java/io/github/nokasegu/post_here/notification/domain/PushSubscriptionEntity.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/domain/PushSubscriptionEntity.java
@@ -18,25 +18,16 @@ import java.time.LocalDateTime;
  * - WebPushService.sendToUser(...)가 특정 사용자에게 푸시 전송 시 이 테이블을 조회한다.
  * <p>
  * [무결성/제약]
- * - endpoint는 각 브라우저가 발급하는 고유 식별자이므로 유니크 제약(uq_push_sub_endpoint)으로 중복 등록을 방지한다.
- * - user_id 인덱스(idx_push_sub_user)로 사용자 단위 조회 성능을 확보한다.
- * - endpoint 길이는 브라우저/벤더에 따라 길어질 수 있어 여유 있게 1000자로 설정.
- * - p256dh/auth는 base64url 형식의 키 문자열이므로 255자로 설정(일반적으로 87~88자 수준).
- * <p>
- * [감사 필드]
- * - createdAt/updatedAt은 JPA Auditing(@EnableJpaAuditing 필요)에 의해 자동 갱신된다.
- * <p>
- * [연관관계]
- * - N:1(UserInfoEntity) LAZY 로딩. 사용자 삭제 정책은 도메인 요구에 따라 별도 처리(연쇄 삭제/보존 등).
- * <p>
- * [확장 포인트]
- * - 기기 타입(OS/브라우저), 구독 상태(활성/비활성), 마지막 성공/실패 시각, 실패 누적 카운트 등의 운영 필드 추가 가능.
+ * - (user_id, endpoint) 복합 유니크 제약으로 같은 브라우저 endpoint라도 유저마다 별도 구독 가능.
+ * - user_id 인덱스로 사용자 단위 조회 성능 확보.
  */
 @Entity
 @Table(
         name = "push_subscription",
         indexes = {@Index(name = "idx_push_sub_user", columnList = "user_id")},
-        uniqueConstraints = {@UniqueConstraint(name = "uq_push_sub_endpoint", columnNames = {"endpoint"})}
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_push_sub_user_endpoint", columnNames = {"user_id", "endpoint"})
+        }
 )
 @Getter
 @Setter

--- a/src/main/java/io/github/nokasegu/post_here/notification/domain/PushSubscriptionEntity.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/domain/PushSubscriptionEntity.java
@@ -3,10 +3,7 @@ package io.github.nokasegu.post_here.notification.domain;
 
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -42,6 +39,7 @@ import java.time.LocalDateTime;
         uniqueConstraints = {@UniqueConstraint(name = "uq_push_sub_endpoint", columnNames = {"endpoint"})}
 )
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/io/github/nokasegu/post_here/notification/dto/NotificationItemResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/dto/NotificationItemResponseDto.java
@@ -2,6 +2,7 @@
 package io.github.nokasegu.post_here.notification.dto;
 
 import io.github.nokasegu.post_here.follow.domain.FollowingEntity;
+import io.github.nokasegu.post_here.forum.domain.ForumCommentEntity;
 import io.github.nokasegu.post_here.notification.domain.NotificationCode;
 import io.github.nokasegu.post_here.notification.domain.NotificationEntity;
 import io.github.nokasegu.post_here.userInfo.domain.UserInfoEntity;
@@ -24,17 +25,102 @@ public class NotificationItemResponseDto {
     private LocalDateTime createdAt;
     private boolean isRead;
 
-    public static NotificationItemResponseDto from(NotificationEntity e) {
-        FollowingEntity f = e.getFollowing();               // FOLLOW 전용 리스트라 가정
-        UserInfoEntity follower = (f != null) ? f.getFollower() : null;
+    // ====================== [추가 필드] ======================
+    // - 댓글 알림(COMMENT)에서 목록에 "댓글 미리보기"를 2줄로 보여주기 위한 원본 텍스트(줄바꿈/공백 정돈 + 길이 제한 적용)
+    // - FOLLOW 등 다른 타입에서는 null 유지 (프런트는 존재할 때만 그려주면 됨)
+    private String commentPreview;
 
-        return NotificationItemResponseDto.builder()
+    // - 알림 클릭 시 이동할 링크. 요구사항: forum 상세는 반드시 GET /forum/{forumId}
+    // - FOLLOW 등에서는 null 가능 (프런트에서 기존 규칙대로 프로필로 이동하는 로직 유지)
+    private String link;
+    // =======================================================
+
+    /**
+     * [기존 주석/의도 유지]
+     * <p>
+     * - FOLLOW 전용으로 작성되어 있었던 부분을 보존하면서,
+     * NotificationCode 기준으로 FOLLOW / COMMENT를 분기 지원하도록 확장.
+     * <p>
+     * - 변경점 요약
+     * 1) type 분기 추가: FOLLOW(기존 로직), COMMENT(댓글 작성자/미리보기/링크 구성)
+     * 2) commentPreview, link 필드 추가 (기존 프론트와의 호환성 깨지지 않도록 선택 필드로 설계)
+     * 3) 기존 필드/명세/주석은 삭제/수정하지 않고 유지
+     */
+    public static NotificationItemResponseDto from(NotificationEntity e) {
+        final NotificationCode code = e.getNotificationCode();
+
+        // 공통 기본값 세팅용 빌더
+        NotificationItemResponseDtoBuilder b = NotificationItemResponseDto.builder()
                 .id(e.getId())
-                .type(e.getNotificationCode())              // "FOLLOW"
-                .actor(NotificationActorDto.of(follower))   // ← 닉네임/대체값까지 보장
-                .text("Started following you")
+                .type(code)
                 .createdAt(e.getCreatedAt())
-                .isRead(Boolean.TRUE.equals(e.getCheckStatus()))
+                .isRead(Boolean.TRUE.equals(e.getCheckStatus()));
+
+        // ===================== [분기: FOLLOW] =====================
+        if (code == NotificationCode.FOLLOW) {
+            FollowingEntity f = e.getFollowing();               // FOLLOW 전용 리스트라 가정
+            UserInfoEntity follower = (f != null) ? f.getFollower() : null;
+
+            return b.actor(NotificationActorDto.of(follower))   // ← 닉네임/대체값까지 보장
+                    .text("Started following you")
+                    // FOLLOW는 목록 클릭 시 프로필로 가는 기존 프런트 로직을 유지하므로 link/commentPreview는 설정하지 않음
+                    .build();
+        }
+
+        // ===================== [분기: COMMENT] =====================
+        if (code == NotificationCode.COMMENT) {
+            // 안전하게 null 체크
+            ForumCommentEntity c = e.getComment();
+            UserInfoEntity actorUser = (c != null) ? c.getWriter() : null;
+
+            // 알림 문구: "<닉네임> 님이 댓글을 남겼습니다"
+            String actorNick = (actorUser != null && actorUser.getNickname() != null)
+                    ? actorUser.getNickname()
+                    : "Someone";
+            String text = actorNick + " 님이 댓글을 남겼습니다";
+
+            // 댓글 미리보기(2줄 클램프 전제)용 백엔드 정리:
+            //  - 줄바꿈/연속 공백 정리
+            //  - 길이 제한(대략 140자) 후 말줄임표 (…) 부여
+            //  - 실제 2줄 렌더링은 프런트 CSS(line-clamp)로 처리, 서버는 1차 안전 가공만 수행
+            String previewSrc = (c != null && c.getContentsText() != null) ? c.getContentsText() : "";
+            String preview = ellipsize(squashWhitespace(previewSrc), 140);
+
+            // 링크 규칙(요구사항 고정): 반드시 GET /forum/{forumId}
+            Long forumId = (c != null && c.getForum() != null) ? c.getForum().getId() : null;
+            String link = (forumId != null) ? ("/forum/" + forumId) : null;
+
+            return b.actor(NotificationActorDto.of(actorUser))
+                    .text(text)
+                    .commentPreview(preview)
+                    .link(link)
+                    .build();
+        }
+
+        // ===================== [기타 타입 기본 처리] =====================
+        // [변경] 기존에 NotificationActorDto.empty()를 호출했으나, 현재 프로젝트에는 empty() 정적 메서드가 없음.
+        //        → null을 넘기면 of(...) 내부에서 대체값을 보장하므로 of(null) 사용.
+        return b.actor(NotificationActorDto.of(null))
+                .text(code != null ? code.name() : "NOTIFICATION")
                 .build();
+    }
+
+    // ===================== [내부 유틸 - 주석 추가] =====================
+    // - squashWhitespace: 줄바꿈/탭/연속 공백을 단일 스페이스로 축약하여 알림 카드에서 안정적으로 보이게 함
+    private static String squashWhitespace(String s) {
+        if (s == null) return "";
+        // \s+ 는 줄바꿈/탭 등 포함 → 한 칸으로 축약
+        String collapsed = s.replaceAll("\\s+", " ").trim();
+        return collapsed;
+    }
+
+    // - ellipsize: 최대 길이를 초과하면 말줄임표(...) 처리
+    //   (2줄 제한은 프런트 CSS로 처리하되, 비정상적으로 긴 한 줄을 방지하기 위한 1차 안전장치)
+    private static String ellipsize(String s, int max) {
+        if (s == null) return "";
+        if (max <= 0) return "";
+        if (s.length() <= max) return s;
+        // 말줄임표는 "..." 고정 (OS 알림/웹 모두에서 일관성)
+        return s.substring(0, Math.max(0, max - 3)) + "...";
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/notification/repository/PushSubscriptionRepository.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/repository/PushSubscriptionRepository.java
@@ -1,4 +1,3 @@
-// src/main/java/io/github/nokasegu/post_here/notification/repository/PushSubscriptionRepository.java
 package io.github.nokasegu.post_here.notification.repository;
 
 import io.github.nokasegu.post_here.notification.domain.PushSubscriptionEntity;
@@ -13,41 +12,11 @@ import java.util.Optional;
  * - Web Push 구독 정보를 영속 계층에서 관리하는 JPA Repository.
  * - WebPushService.sendToUser(...)가 사용자별 구독 목록을 조회하는 주요 진입점.
  */
-
-/**
- * [알림 생성 + 푸시 발사 사용 지점]
- * - WebPushService.sendToUser(...)에서 대상 유저의 구독 목록을 조회할 때 사용합니다.
- * - findAllByUser(...) 결과를 순회하며 각 endpoint로 푸시를 전송하는 구조입니다.
- */
-
-/**
- * PushSubscriptionRepository
- * <p>
- * - 웹 푸시 알림(Web Push API)에서 사용자의 구독 정보를 DB에 저장/조회하기 위한 Repository
- * - 구독 정보(PushSubscriptionEntity)는 브라우저별 endpoint, 키 값 등을 포함
- * <p>
- * 작동 원리:
- * 1. 사용자가 알림을 허용하면 브라우저가 push 구독 정보를 생성
- * 2. 서버가 해당 구독 정보를 PushSubscriptionEntity로 저장
- * 3. 알림 발송 시 UserInfoEntity와 연결된 모든 구독 정보를 조회
- * 4. 각 endpoint로 푸시 서버에 메시지를 전달 → 브라우저에서 알림 표시
- * <p>
- * 메서드 설명:
- * - findAllByUser(UserInfoEntity user)
- * → 특정 유저의 모든 구독 정보를 반환 (디바이스/브라우저별 복수 지원)
- * <p>
- * - findByEndpoint(String endpoint)
- * → 이미 존재하는 구독인지 확인 (중복 방지용)
- * <p>
- * 확장 포인트:
- * - 향후 댓글, 좋아요, 친구 요청, 시스템 알림 등 다양한 알림 유형에서도 동일 구독 정보를 활용
- * - 필요 시 구독 상태(활성/비활성), 기기 타입, 알림 환경설정 필드 등을 추가 가능
- */
 public interface PushSubscriptionRepository extends JpaRepository<PushSubscriptionEntity, Long> {
 
     // 특정 사용자(UserInfoEntity)에 연결된 모든 푸시 구독 정보 조회
     List<PushSubscriptionEntity> findAllByUser(UserInfoEntity user);
 
-    // endpoint 값으로 구독 정보 단건 조회 (중복 등록 방지)
-    Optional<PushSubscriptionEntity> findByEndpoint(String endpoint);
+    // [변경] endpoint만으로 찾으면 중복 문제 발생 → user + endpoint 조합으로 조회
+    Optional<PushSubscriptionEntity> findByUserAndEndpoint(UserInfoEntity user, String endpoint);
 }

--- a/src/main/java/io/github/nokasegu/post_here/notification/service/FcmSenderService.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/service/FcmSenderService.java
@@ -10,6 +10,16 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.*;
 
+/**
+ * FcmSenderService
+ * <p>
+ * [역할]
+ * - FirebaseMessaging을 사용해 단건/멀티캐스트/폴백 발송 처리
+ * <p>
+ * [변경/추가]
+ * - [추가 로그] 토큰 수집/개수/꼬리/발송 성패/예외를 INFO/WARN 로그로 더 명확히 기록
+ * - [안정성] 빈 토큰 리스트 시 명시적으로 skip 로그 남김
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -33,10 +43,12 @@ public class FcmSenderService {
         try {
             Message message = buildMessage(token, title, body, data);
             String messageId = firebaseMessaging.send(message);
+            // [추가 로그]
             log.info("[FCM] Sent(one) id={}, tokenTail={}", messageId, tail(token));
             return messageId;
         } catch (Exception e) {
-            log.error("[FCM] Failed(one) tokenTail={} err={}", tail(token), e.toString(), e);
+            // [추가 로그]
+            log.warn("[FCM] Failed(one) tokenTail={} err={}", tail(token), e.toString(), e);
             throw new RuntimeException("FCM send failed", e);
         }
     }
@@ -58,8 +70,15 @@ public class FcmSenderService {
                 .toList();
 
         if (list.isEmpty()) {
-            log.info("[FCM] No tokens to send.");
+            // [추가 로그]
+            log.info("[FCM] No tokens to send. title='{}'", title);
             return FcmBatchResult.empty();
+        }
+
+        // [추가 로그]
+        if (log.isInfoEnabled()) {
+            String tails = list.stream().map(FcmSenderService::tail).reduce((a, b) -> a + "," + b).orElse("");
+            log.info("[FCM] Multicast try: total={}, tails=[{}], title='{}'", list.size(), tails, title);
         }
 
         // 1) 우선 멀티캐스트 시도
@@ -69,6 +88,7 @@ public class FcmSenderService {
 
             int success = br.getSuccessCount();
             int failure = br.getFailureCount();
+            // [추가 로그]
             log.info("[FCM] Multicast sent: total={}, success={}, failure={}", list.size(), success, failure);
 
             List<String> failedTokens = new ArrayList<>();
@@ -78,6 +98,7 @@ public class FcmSenderService {
                     String tok = list.get(i);
                     failedTokens.add(tok);
                     String msg = r.getException() != null ? r.getException().getMessage() : "unknown";
+                    // [추가 로그]
                     log.warn("[FCM] failed tokenTail={} err={}", tail(tok), msg);
 
                     // [선택] 무효 토큰 정리 예시
@@ -91,13 +112,16 @@ public class FcmSenderService {
             // 2) 배치 404면 개별 전송 폴백
             String msg = e.getMessage();
             if (msg != null && msg.contains("/batch") && msg.contains("404")) {
+                // [추가 로그]
                 log.warn("[FCM] batch 404 detected. Fallback to per-token send...");
                 return fallbackSendIndividually(list, title, body, data);
             }
-            log.error("[FCM] Multicast send failed: {}", e.toString(), e);
+            // [추가 로그]
+            log.warn("[FCM] Multicast send failed: {}", e.toString(), e);
             throw new RuntimeException("FCM multicast send failed", e);
         } catch (Exception e) {
-            log.error("[FCM] Multicast send failed: {}", e.toString(), e);
+            // [추가 로그]
+            log.warn("[FCM] Multicast send failed: {}", e.toString(), e);
             throw new RuntimeException("FCM multicast send failed", e);
         }
     }
@@ -116,6 +140,7 @@ public class FcmSenderService {
         }
         int total = tokens.size();
         int failure = total - success;
+        // [추가 로그]
         log.info("[FCM] Fallback send(one-by-one) total={}, success={}, failure={}", total, success, failure);
         return new FcmBatchResult(total, success, failure, failed);
     }
@@ -143,8 +168,33 @@ public class FcmSenderService {
         );
         List<String> tokens = resolveFcmTokens(targetUser);
         if (tokens.isEmpty()) {
+            // [추가 로그]
             log.info("[FCM] No native tokens for target user (id={}). Skip sending FOLLOW.",
-                    targetUser != null ? String.valueOf(targetUser.getId()) : "null");
+                    (targetUser != null ? String.valueOf(targetUser.getId()) : "null"));
+            return;
+        }
+        sendToTokens(tokens, title, body, data);
+    }
+
+    // [신규 오버로드] 댓글 알림: 수신자 엔티티 입력받아 내부에서 토큰 해석
+    public void sendComment(UserInfoEntity targetUser, String actorNickname, String preview, Long forumId, Long notificationId) {
+        String title = "새 댓글";
+        String body = actorNickname + " 님이 댓글을 남겼습니다.";
+        Map<String, String> data = new HashMap<>();
+        data.put("type", "COMMENT");
+        if (forumId != null) data.put("forumId", String.valueOf(forumId));
+        data.put("notificationId", String.valueOf(notificationId));
+        data.put("actorNickname", actorNickname != null ? actorNickname : "");
+        // [선택] 프리뷰를 data로도 전송할 수 있음(앱이 활용)
+        if (preview != null && !preview.isBlank()) {
+            data.put("preview", preview);
+        }
+
+        List<String> tokens = resolveFcmTokens(targetUser);
+        if (tokens.isEmpty()) {
+            // [추가 로그]
+            log.info("[FCM] No native tokens for target user (id={}). Skip sending COMMENT.",
+                    (targetUser != null ? String.valueOf(targetUser.getId()) : "null"));
             return;
         }
         sendToTokens(tokens, title, body, data);
@@ -213,10 +263,21 @@ public class FcmSenderService {
 
     // ===== 실제 토큰 조회 (A안: user_info.fcm_token 사용) =====
     protected List<String> resolveFcmTokens(UserInfoEntity targetUser) {
-        if (targetUser == null) return List.of();
+        if (targetUser == null) {
+            // [추가 로그]
+            log.info("[FCM] resolve tokens: targetUser is null");
+            return List.of();
+        }
         String t = targetUser.getFcmToken();
-        if (t == null || t.isBlank()) return List.of();
-        return List.of(t.trim());
+        if (t == null || t.isBlank()) {
+            // [추가 로그]
+            log.info("[FCM] resolve tokens: userId={} => NO_TOKEN", targetUser.getId());
+            return List.of();
+        }
+        String token = t.trim();
+        // [추가 로그]
+        log.info("[FCM] resolve tokens: userId={} => 1 token (tail={})", targetUser.getId(), tail(token));
+        return List.of(token);
     }
 
     // ===== DTO =====

--- a/src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
@@ -1,3 +1,4 @@
+// src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
 package io.github.nokasegu.post_here.notification.service;
 
 import io.github.nokasegu.post_here.follow.domain.FollowingEntity;

--- a/src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
@@ -1,6 +1,10 @@
+// src/main/java/io/github/nokasegu/post_here/notification/service/NotificationService.java
 package io.github.nokasegu.post_here.notification.service;
 
 import io.github.nokasegu.post_here.follow.domain.FollowingEntity;
+import io.github.nokasegu.post_here.follow.repository.FollowingRepository;
+import io.github.nokasegu.post_here.forum.domain.ForumCommentEntity;
+import io.github.nokasegu.post_here.forum.repository.ForumCommentRepository;
 import io.github.nokasegu.post_here.notification.domain.NotificationCode;
 import io.github.nokasegu.post_here.notification.domain.NotificationEntity;
 import io.github.nokasegu.post_here.notification.dto.NotificationItemResponseDto;
@@ -29,53 +33,67 @@ public class NotificationService {
     private final WebPushService webPushService;
     private final FcmSenderService fcmSenderService;
 
+    // ===================== [추가] 안전 재조회용 리포지토리 =====================
+    private final ForumCommentRepository forumCommentRepository;
+    private final FollowingRepository followingRepository;
+    // ======================================================================
+
     /**
      * AFTER_COMMIT 리스너에서 호출되는 알림 생성/전송 메서드.
      * 기존 트랜잭션이 이미 끝난 뒤 실행되므로 "새 트랜잭션"을 강제로 시작한다.
      * (transactionManager 이름은 JPA TM 빈 이름에 맞게 필요 시 변경)
+     * <p>
+     * [중요 변경]
+     * - REQUIRES_NEW 진입 직후, 전달받은 FollowingEntity를 "ID 기반으로 재조회(fetch-join)" 하여
+     * 지연로딩을 안전하게 처리한다.
+     * - 전송 순서: FCM → Web Push (둘 다 시도)
      */
     @Transactional(transactionManager = "transactionManager", propagation = Propagation.REQUIRES_NEW)
     public NotificationEntity createFollowAndPush(FollowingEntity following) {
-        log.info("[NOTI] createFollowAndPush START");
-        log.info("[NOTI] before save");
+        Long fid = (following != null ? following.getId() : null);
+        // [추가 로그]
+        log.info("[NOTI] createFollowAndPush called. followingId={}", fid);
 
-        NotificationEntity n = NotificationEntity.builder()
-                .notificationCode(NotificationCode.FOLLOW)
-                .following(following)
-                .targetUser(following.getFollowed())
-                .checkStatus(false)
-                .build();
-
-        // PK 바로 채우도록 flush까지 보장
-        NotificationEntity saved = notificationRepository.saveAndFlush(n);
-        log.info("[NOTI] after save id={}", saved.getId());
-
-        // Web Push
-        log.info("[NOTI] webPush send start");
-        try {
-            webPushService.sendToUser(following.getFollowed(), buildFollowPayload(saved, following));
-        } catch (Exception e) {
-            // [핵심 수정] 외부 알림 실패가 DB 트랜잭션을 망치지 않도록 예외 삼킴
-            log.warn("[NOTI] webPush send failed id={}, err={}", saved.getId(), e.toString());
+        if (fid == null) {
+            log.warn("[NOTI] createFollowAndPush skipped: following id is null");
+            return null;
         }
-        log.info("[NOTI] webPush send end");
+        FollowingEntity f = followingRepository.findByIdWithBothUsers(fid)
+                .orElseThrow(() -> new IllegalArgumentException("Following not found: id=" + fid));
 
-        // FCM
-        log.info("[NOTI] fcm send start");
+        NotificationEntity saved = notificationRepository.saveAndFlush(
+                NotificationEntity.builder()
+                        .notificationCode(NotificationCode.FOLLOW)
+                        .following(f)                         // ← 다시 조회한 f 사용
+                        .targetUser(f.getFollowed())
+                        .checkStatus(false)
+                        .build()
+        );
+        // [추가 로그]
+        log.info("[NOTI] FOLLOW saved. notiId={} targetUserId={} actorId={}",
+                saved.getId(),
+                (f.getFollowed() != null ? f.getFollowed().getId() : null),
+                (f.getFollower() != null ? f.getFollower().getId() : null));
+
+        // 1) FCM (최우선)
         try {
             fcmSenderService.sendFollow(
-                    following.getFollowed(),
-                    following.getFollower().getNickname(),
-                    following.getFollower().getProfilePhotoUrl(),
+                    f.getFollowed(),
+                    f.getFollower().getNickname(),
+                    f.getFollower().getProfilePhotoUrl(),
                     saved.getId()
             );
         } catch (Exception e) {
-            // [핵심 수정] FCM 실패도 트랜잭션 롤백시키지 않음
-            log.warn("[NOTI] fcm send failed id={}, err={}", saved.getId(), e.toString());
+            log.warn("[NOTI] FCM send failed (FOLLOW) id={}, err={}", saved.getId(), e.toString());
         }
-        log.info("[NOTI] fcm send end");
 
-        log.info("[NOTI] createFollowAndPush END id={}", saved.getId());
+        // 2) Web Push (보조)
+        try {
+            webPushService.sendToUser(f.getFollowed(), buildFollowPayload(saved, f));
+        } catch (Exception e) {
+            log.warn("[NOTI] WebPush send failed (FOLLOW) id={}, err={}", saved.getId(), e.toString());
+        }
+
         return saved;
     }
 
@@ -89,12 +107,108 @@ public class NotificationService {
                 actor.put("profilePhotoUrl", following.getFollower().getProfilePhotoUrl());
             }
         }
-
         Map<String, Object> payload = new HashMap<>();
         payload.put("type", "FOLLOW");
         payload.put("notificationId", saved.getId());
         payload.put("actor", actor);
         payload.put("text", "Started following you");
+        return payload;
+    }
+
+    // ===================== 댓글 알림 (REQUIRES_NEW + 안전 재조회) =====================
+    @Transactional(transactionManager = "transactionManager", propagation = Propagation.REQUIRES_NEW)
+    public NotificationEntity createCommentAndPush(ForumCommentEntity comment) {
+        Long cid = (comment != null ? comment.getId() : null);
+        // [추가 로그]
+        log.info("[NOTI] createCommentAndPush called. commentId={}", cid);
+
+        if (cid == null) {
+            log.warn("[NOTI] createCommentAndPush skipped: comment id is null");
+            return null;
+        }
+        ForumCommentEntity c = forumCommentRepository.findByIdWithWriterAndForumWriter(cid)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found: id=" + cid));
+
+        final UserInfoEntity receiver = c.getForum().getWriter(); // 게시글 작성자
+        final UserInfoEntity actor = c.getWriter();               // 댓글 작성자
+        if (receiver.getId().equals(actor.getId())) {
+            // 자기 글에 자기 댓글이면 알림 스킵
+            log.info("[NOTI] COMMENT skipped (self-comment). forumWriterId={}", receiver.getId());
+            return null;
+        }
+
+        NotificationEntity saved = notificationRepository.saveAndFlush(
+                NotificationEntity.builder()
+                        .notificationCode(NotificationCode.COMMENT)
+                        .comment(c)                 // ← 다시 조회한 c 사용
+                        .targetUser(receiver)
+                        .checkStatus(false)
+                        .build()
+        );
+        // [추가 로그]
+        log.info("[NOTI] COMMENT saved. notiId={} targetUserId={} actorId={} forumId={}",
+                saved.getId(),
+                receiver.getId(),
+                actor.getId(),
+                (c.getForum() != null ? c.getForum().getId() : null));
+
+        String actorNick = actor.getNickname() != null ? actor.getNickname() : "Someone";
+        String preview = preview(c);
+        Long forumId = c.getForum() != null ? c.getForum().getId() : null;
+        // [추가 로그]
+        log.info("[NOTI] COMMENT send. actorNick='{}' previewLen={} forumId={}",
+                actorNick, (preview != null ? preview.length() : 0), forumId);
+
+        // 1) FCM (최우선)
+        try {
+            fcmSenderService.sendComment(receiver, actorNick, preview, forumId, saved.getId());
+        } catch (Exception e) {
+            log.warn("[NOTI] FCM send failed (COMMENT) id={}, err={}", saved.getId(), e.toString());
+        }
+
+        // 2) Web Push (보조)
+        try {
+            webPushService.sendToUser(receiver, buildCommentPayload(saved, c));
+        } catch (Exception e) {
+            log.warn("[NOTI] WebPush send failed (COMMENT) id={}, err={}", saved.getId(), e.toString());
+        }
+
+        return saved;
+    }
+
+    private String preview(ForumCommentEntity c) {
+        String src = (c != null && c.getContentsText() != null) ? c.getContentsText() : "";
+        String collapsed = src.replaceAll("\\s+", " ").trim();
+        if (collapsed.length() <= 140) return collapsed;
+        return collapsed.substring(0, 137) + "...";
+    }
+
+    private Map<String, Object> buildCommentPayload(NotificationEntity saved, ForumCommentEntity comment) {
+        Map<String, Object> actor = new HashMap<>();
+        if (comment.getWriter() != null) {
+            if (comment.getWriter().getNickname() != null) {
+                actor.put("nickname", comment.getWriter().getNickname());
+            }
+            if (comment.getWriter().getProfilePhotoUrl() != null) {
+                actor.put("profilePhotoUrl", comment.getWriter().getProfilePhotoUrl());
+            }
+        }
+        Long forumId = (comment.getForum() != null) ? comment.getForum().getId() : null;
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("notificationId", String.valueOf(saved.getId()));
+        if (forumId != null) data.put("forumId", String.valueOf(forumId));
+        data.put("actorNickname", (String) actor.getOrDefault("nickname", "Someone"));
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", "COMMENT");
+        payload.put("notificationId", saved.getId());
+        payload.put("actor", actor);
+        payload.put("title", "새 댓글");
+        payload.put("body", actor.getOrDefault("nickname", "누군가") + " 님이 댓글을 남겼습니다");
+        // [요구사항] 클릭 시 반드시 GET /forum/{forumId}
+        payload.put("url", (forumId != null) ? ("/forum/" + forumId) : "/notification");
+        payload.put("data", data);
         return payload;
     }
 
@@ -106,24 +220,21 @@ public class NotificationService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
 
         List<NotificationEntity> entities =
-                notificationRepository.findListByTarget(target, PageRequest.of(page, size));
+                notificationRepository.findUnifiedListByTarget(target, PageRequest.of(page, size));
 
         List<NotificationItemResponseDto> items = entities.stream()
                 .map(NotificationItemResponseDto::from)
                 .toList();
 
         long unreadCount = notificationRepository.countByTargetUserAndCheckStatusIsFalse(target);
-
         return NotificationListResponseDto.of(items, unreadCount);
     }
 
     @Transactional(transactionManager = "transactionManager")
     public int markRead(Long targetUserId, List<Long> notificationIds) {
         if (notificationIds == null || notificationIds.isEmpty()) return 0;
-
         UserInfoEntity target = userInfoRepository.findById(targetUserId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-
         return notificationRepository.markReadByIds(target, notificationIds);
     }
 
@@ -131,7 +242,6 @@ public class NotificationService {
     public int markAllRead(Long targetUserId) {
         UserInfoEntity target = userInfoRepository.findById(targetUserId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-
         return notificationRepository.markAllRead(target);
     }
 
@@ -139,7 +249,6 @@ public class NotificationService {
     public long unreadCount(Long targetUserId) {
         UserInfoEntity target = userInfoRepository.findById(targetUserId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-
         return notificationRepository.countByTargetUserAndCheckStatusIsFalse(target);
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/notification/service/WebPushService.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/service/WebPushService.java
@@ -8,110 +8,72 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
-import org.jose4j.lang.JoseException;
+import org.apache.http.HttpResponse;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
-/**
- * [알림 생성 + 푸시 발사 연결 지점]
- * - FollowingService.follow(...) 성공
- * → NotificationService.createFollowAndPush(...)
- * → WebPushService.sendToUser(...) 에서 실제 Web Push 전송
- * <p>
- * [전제/의존]
- * - CryptoProviderConfig 등에서 애플리케이션 기동 시 BouncyCastle 등록 필요
- * - build.gradle: web-push(java), bcprov, bcpkix, gson 의존성 포함
- * - application-secret.yml: webpush.subject / webpush.publicKey / webpush.privateKey
- * <p>
- * [SW 연계]
- * - service-worker.js 'push' 핸들러가 수신 가능한 JSON 스키마를 준수해야 함
- * (예: { type, notificationId, actor{nickname,profilePhotoUrl}, text })
- */
 
 /**
  * WebPushService
- * <p>
- * - 외부 라이브러리 nl.martijndwars.webpush.PushService 를 감싸는 어댑터 서비스
- * - VAPID 키 기반으로 Web Push 암호화/서명을 처리하고, 브라우저 endpoint로 알림 전송
- * <p>
- * 작동 원리:
- * 1. 사용자(UserInfoEntity)에 연결된 모든 PushSubscriptionEntity 를 DB에서 조회
- * 2. payload(Map)를 JSON 직렬화 후 바이트 배열로 변환
- * 3. PushService (외부 라이브러리)로 Notification 객체 생성 (endpoint, p256dh, auth, payload)
- * 4. send() 호출 → 브라우저 푸시 서버를 통해 클라이언트로 전달
- * <p>
- * 구현 포인트:
- * - buildClient() : VAPID subject/public/private 키로 PushService 초기화
- * - sendToUser() : 특정 유저에게 등록된 모든 endpoint로 반복 전송
- * - IOException, JoseException, ExecutionException 발생 시 로그만 기록
- * - InterruptedException 은 반드시 Thread.currentThread().interrupt() 로 복구 후 중단
- * <p>
- * 확장 포인트:
- * - 현재는 JSON 직렬화만 지원하지만, 향후 payload 구조 확장 가능
- * - 실패한 endpoint 를 DB에서 제거하는 로직 추가 가능
- * - 푸시 메시지 우선순위, TTL(Time-To-Live) 같은 설정값 확장 가능
+ * - PushSubscriptionRepository 에 저장된 endpoint/p256dh/auth 값을 불러와
+ * VAPID 키로 서명한 WebPush Notification을 전송한다.
+ * - 실패 시(404/410 Gone) 구독 정보를 DB에서 삭제한다.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class WebPushService {
+    private final PushSubscriptionRepository pushRepo;
+    private final WebPushProperties props;
 
-    // 순환 의존 방지: NotificationService 를 직접 주입하지 않음
-    // private final NotificationService notificationService;
-
-    private final WebPushProperties props;               // VAPID 키/subject 등 구성 정보
-    private final PushSubscriptionRepository pushRepo;   // 사용자 구독 정보 저장소
-    private final Gson gson = new Gson();                // payload 직렬화용
-
-    /**
-     * PushService 클라이언트 생성 (외부 라이브러리)
-     * - VAPID subject, public/private 키를 설정
-     */
-    private PushService buildClient() throws GeneralSecurityException {
-        PushService svc = new PushService();
-        svc.setSubject(props.getSubject());
-        svc.setPublicKey(props.getPublicKey());
-        svc.setPrivateKey(props.getPrivateKey());
-        return svc;
-    }
-
-    /**
-     * 특정 사용자에게 Web Push 알림 전송
-     *
-     * @param target  알림 받을 사용자
-     * @param payload JSON으로 직렬화될 데이터(Map<String, Object>)
-     */
-    public void sendToUser(UserInfoEntity target, Map<String, Object> payload) {
-        List<PushSubscriptionEntity> subs = pushRepo.findAllByUser(target);
-        if (subs.isEmpty()) return;
-
-        final byte[] data = gson.toJson(payload).getBytes(StandardCharsets.UTF_8);
-
-        try {
-            PushService client = buildClient();
-
-            for (PushSubscriptionEntity s : subs) {
-                try {
-                    // 브라우저 endpoint + 키 정보 + 데이터로 Notification 객체 생성
-                    Notification n = new Notification(s.getEndpoint(), s.getP256dh(), s.getAuth(), data);
-                    client.send(n); // 실제 전송
-                } catch (IOException | JoseException | ExecutionException e) {
-                    log.warn("WebPush send fail endpoint={}", s.getEndpoint(), e);
-                } catch (InterruptedException e) {
-                    // 인터럽트 신호 복구 필수
-                    Thread.currentThread().interrupt();
-                    log.warn("WebPush send interrupted endpoint={}", s.getEndpoint(), e);
-                    return; // 현재 스레드가 인터럽트된 상태이므로 루프 중단
-                }
-            }
-        } catch (GeneralSecurityException e) {
-            log.error("WebPush init error", e);
+    public void sendToUser(UserInfoEntity user, Map<String, Object> payload) {
+        List<PushSubscriptionEntity> subs = pushRepo.findAllByUser(user);
+        if (subs.isEmpty()) {
+            log.info("[WebPush] no subscriptions for user {}", user.getId());
+            return;
         }
+
+        int ok = 0, gone = 0, other = 0;
+        Gson gson = new Gson();
+
+        for (PushSubscriptionEntity sub : subs) {
+            try {
+                PushService service = new PushService();
+                service.setPublicKey(props.getPublicKey());
+                service.setPrivateKey(props.getPrivateKey());
+                service.setSubject(props.getSubject());
+
+                byte[] body = gson.toJson(payload).getBytes(StandardCharsets.UTF_8);
+
+                Notification n = new Notification(
+                        sub.getEndpoint(),
+                        sub.getP256dh(),
+                        sub.getAuth(),
+                        body
+                );
+
+                HttpResponse res = service.send(n);
+                int status = res.getStatusLine().getStatusCode();
+
+                if (status == 201) {
+                    ok++;
+                } else if (status == 404 || status == 410) {
+                    pushRepo.delete(sub);
+                    gone++;
+                } else {
+                    other++;
+                    log.warn("[WebPush] non-201 status={} endpointTail={}", status,
+                            sub.getEndpoint().substring(Math.max(0, sub.getEndpoint().length() - 12)));
+                }
+            } catch (Exception ex) {
+                log.warn("[WebPush] send failed endpointTail={}",
+                        sub.getEndpoint().substring(Math.max(0, sub.getEndpoint().length() - 12)), ex);
+                other++;
+            }
+        }
+        log.info("[WebPush] done userId={} result: ok={}, gone={}, other={}",
+                user.getId(), ok, gone, other);
     }
 }

--- a/src/main/java/io/github/nokasegu/post_here/userInfo/domain/UserInfoEntity.java
+++ b/src/main/java/io/github/nokasegu/post_here/userInfo/domain/UserInfoEntity.java
@@ -18,18 +18,21 @@ import java.time.LocalDateTime;
  * · loginPw: 로그인 비밀번호(저장 시 해시 전제)
  * · nickname: 서비스 내 표시명
  * · profilePhotoUrl: 프로필 이미지 경로/URL
+ * · fcmToken: 네이티브 앱 푸시 알림 수신용 토큰
  * · createdAt/updatedAt: 생성/수정 시각(JPA Auditing)
  * <p>
  * 사용처(정확 명칭)
  * - 팔로우 관계: FollowingEntity.follower / FollowingEntity.followed 에서 참조
  * - 알림 수신자: NotificationEntity.targetUser 에서 참조
  * - Web Push 구독 주체: PushSubscriptionEntity.user (구독 목록 조회/전송 대상 식별)
+ * - FCM 알림 수신자: FcmSenderService에서 토큰 조회 및 전송에 사용
  * <p>
  * 보안/설계 메모
  * - loginPw: 반드시 해시(예: BCrypt)로 저장하고 평문/가역암호 금지.
  * - email: 로그인/중복 체크에 사용하면 DB 유니크 제약 권장.
  * - nickname: 검색/정렬에 자주 쓰이면 인덱스 고려.
  * - profilePhotoUrl: 외부 URL 저장 시 길이/검증 정책 필요(현재 length=500).
+ * - fcmToken: 기기당 1개 토큰만 저장. 다중 기기 지원이 필요하면 별도 테이블 분리 권장.
  * - Auditing 사용: @EnableJpaAuditing 활성화 전제, createdAt은 updatable=false.
  */
 @Entity
@@ -70,6 +73,14 @@ public class UserInfoEntity {
      */
     @Column(name = "profile_photo_url", length = 500)
     private String profilePhotoUrl;
+
+    /**
+     * 네이티브 앱 FCM 푸시 토큰
+     * - PushTokenController.saveToken()에서 업데이트
+     * - FcmSenderService.resolveFcmTokens()에서 조회
+     */
+    @Column(name = "fcm_token", length = 512)
+    private String fcmToken;
 
     /**
      * 생성 시각(Auditing) — 수정 불가

--- a/src/main/js/modules/push-subscription.js
+++ b/src/main/js/modules/push-subscription.js
@@ -137,5 +137,9 @@ export function initPushSubscribe() {
         } else {
             console.log('[push] no existing subscription.');
         }
+
     };
+
+    fetchVapidKeyAndStart();
+    
 }

--- a/src/main/js/modules/pwa.js
+++ b/src/main/js/modules/pwa.js
@@ -1,18 +1,26 @@
+// src/main/js/pwa.js
 import {initPushSubscribe} from "./push-subscription";
+
 
 // === 페이지 로드 시 실행 ===
 // (기존 코드 유지: load 시 /service-worker.js 등록 + 이후 공개키 fetch 시작)
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', async () => {
+
+        window.__pwaLoaded = true; // [추가] 디버그용 전역 플래그
+        console.log('[pwa] pwa.js LOADED');
+
         try {
             // ✅ 기존 기능: 로드 시 SW 등록 (동일 경로/스코프)
             const reg = await navigator.serviceWorker.register('/service-worker.js');
             console.log('[push] SW registered:', reg.scope);
 
-            //푸시 알림 구독
+            // 푸시 알림 구독
+            // [설명] initPushSubscribe 내부에서 fetchVapidKeyAndStart()가 실행됨.
+            //        따라서 여기서는 따로 fetchVapidKeyAndStart()를 호출할 필요 없음.
             initPushSubscribe();
 
-            //서비스 워커로부터 오는 메시지(알림 클릭 등) 처리
+            // 서비스 워커로부터 오는 메시지(알림 클릭 등) 처리
             navigator.serviceWorker.addEventListener('message', (e) => {
                 if (e.data?.type === 'NAVIGATE') {
                     const url = new URL(e.data.url, location.origin).toString();

--- a/src/main/js/pages/notification.js
+++ b/src/main/js/pages/notification.js
@@ -97,10 +97,15 @@ export function initNotification() {
             const createdAt = it.createdAt ?? it.created_at ?? null;
             const read = (typeof it.read === 'boolean') ? it.read : (typeof it.checkStatus === 'boolean') ? it.checkStatus : (typeof it.checked === 'boolean') ? it.checked : false;
 
+            // ===================== [변경] 링크 우선순위 =====================
+            // - 댓글 알림(COMMENT)에는 백엔드가 내려준 link(/forum/{id})가 존재
+            // - FOLLOW 등 기존 규칙은 프로필로 이동
+            const link = it.link || (actorNick ? `/profile/${encodeURIComponent(actorNick)}` : '#');
+
             const row = document.createElement('a');
             row.className = 'noti-card';
             if (id != null) row.dataset.id = String(id);
-            row.href = actorNick ? `/profile/${encodeURIComponent(actorNick)}` : '#';
+            row.href = link; // [변경] it.link 우선
             row.setAttribute('aria-label', actorNick ? `${actorNick} ${text}` : text);
             row.dataset.unread = String(!read);
 
@@ -130,6 +135,16 @@ export function initNotification() {
             textEl.textContent = String(text);
             main.appendChild(head);
             main.appendChild(textEl);
+
+            // ===================== [신규] 댓글 미리보기(2줄 클램프) =====================
+            if (it.commentPreview) {
+                const pv = document.createElement('div');
+                pv.className = 'noti-preview'; // CSS에서 2줄 line-clamp
+                pv.textContent = String(it.commentPreview);
+                main.appendChild(pv);
+            }
+            // ========================================================================
+
             row.appendChild(main);
             frag.appendChild(row);
         });

--- a/src/main/resources/static/css/notification.css
+++ b/src/main/resources/static/css/notification.css
@@ -183,3 +183,15 @@ a.noti-card:active {
     line-height: 1.3;
     word-break: break-word;
 }
+
+.noti-preview {
+    display: -webkit-box;
+    -webkit-line-clamp: 2; /* 2줄 클램프 */
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    word-break: break-word;
+    margin-top: 2px;
+    font-size: 0.94rem; /* 본문보다 살짝 작게 */
+    line-height: 1.32;
+    opacity: 0.9;
+}


### PR DESCRIPTION
## 구현 내용 요약
- 팔로우 시 팔로우 당한 유저에게 푸시 알림 발송
- Forum 댓글 작성 시 해당 게시글 작성자에게 푸시 알림 발송

---

## 관련 이슈
Closes #128  
Closes #31  

---

## 작업 상세 내역
- NotificationService
  - createFollowNotification(followeeId, followerId) 구현 → 팔로우 발생 시 알림 DB 저장 및 FCM 발송
  - createCommentNotification(authorId, postId, commentId) 구현 → 댓글 발생 시 알림 DB 저장 및 FCM 발송
- FollowingRepository : followee 단일 조회 메소드 추가
- ForumCommentService : addComment(...) 내 댓글 저장 후 알림 생성 트리거 추가
- NotificationRepository : follow/comment 알림 저장 및 조회 메소드 보강
- NotificationItemResponseDto : 알림 타입, 딥링크, timeAgo 필드 추가
- FcmSenderService : 댓글/팔로우용 send 메소드 구현, 공통 전송 로직 정리
- FirebaseConfig : 프로필별 안전 초기화 및 예외 처리 보강
- 프론트엔드 (notification.js, notification.css)
  - /notification/list 로드 → 즉시 읽음 처리 및 unread-count 갱신
  - 알림 클릭 시 게시글/댓글/프로필로 라우팅
  - 읽음/안읽음 상태 및 리스트 스타일 개선

---

## from to
<feature/notification-push> -> <main>

---
