### PR TITLE
[수정] Forum 댓글 입력창 아바타가 글 작성자 사진으로 표시되는 문제 수정 #141

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumController.java
@@ -33,7 +33,20 @@ public class ForumController {
     }
 
     @GetMapping("/forumMain")
-    public String forumPage(Model model) {
+    public String forumPage(Model model, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        // [수정] 댓글 입력창(모달)에서 "로그인 사용자" 아바타를 표시하기 위해
+        //        현재 로그인 유저 정보를 'me'로 모델에 주입합니다.
+        //        - 템플릿(main.html)에서 window.__ME__로 직렬화하여 JS에서 사용합니다.
+        if (userDetails != null && userDetails.getUserInfo() != null) {
+            var u = userDetails.getUserInfo();
+            java.util.Map<String, Object> me = new java.util.HashMap<>();
+            me.put("id", u.getId());
+            me.put("nickname", u.getNickname());
+            me.put("profilePhotoUrl", u.getProfilePhotoUrl());
+            model.addAttribute("me", me);
+        } else {
+            model.addAttribute("me", null);
+        }
         return "forum/main";
     }
 

--- a/src/main/js/pages/main.js
+++ b/src/main/js/pages/main.js
@@ -276,7 +276,10 @@ export function initMain() {
                     </div>
                     <div class="comment-modal-footer">
                         <div class="comment-form-inner">
-                            <img src="${postData.writerProfilePhotoUrl}" alt="내 프로필" class="profile-img">
+                            <!-- [수정] 댓글 입력창 왼쪽 아바타는 로그인 사용자(me) 기준으로 표시합니다.
+                                 - 여기서는 src를 비워두고 id를 부여한 뒤, append 후 JS로 채웁니다.
+                                 - window.__ME__가 없거나 게스트인 경우 글 작성자 사진으로 폴백합니다. -->
+                            <img id="comment-editor-avatar" alt="내 프로필" class="profile-img">
                             <form class="comment-form">
                                 <input class="comment-input" placeholder="댓글을 작성하세요." required type="text">
                                 <button class="comment-submit" type="submit">게시</button>
@@ -290,6 +293,16 @@ export function initMain() {
 
         const modal = $('#comment-modal');
         modal.data('post-card', postCard);
+
+        // [수정] 아바타 src 채우기 로직: window.__ME__ → 폴백(postData.writerProfilePhotoUrl)
+        (function fillCommentAvatar() {
+            const me = (typeof window !== 'undefined') ? window.__ME__ : null;
+            const avatarSrc = (me && me.profilePhotoUrl) ? me.profilePhotoUrl : postData.writerProfilePhotoUrl;
+            const altText = (me && me.nickname) ? me.nickname : '내 프로필';
+            modal.find('#comment-editor-avatar')
+                .attr('src', avatarSrc)
+                .attr('alt', altText);
+        })();
 
         setTimeout(() => {
             modal.addClass('show');

--- a/src/main/resources/templates/forum/main.html
+++ b/src/main/resources/templates/forum/main.html
@@ -8,6 +8,16 @@
     <link href="https://fonts.googleapis.com/css2?family=Agbalumo&display=swap" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link href="/pwa/manifest.json" rel="manifest">
+
+    <!-- [수정] 로그인 사용자(me) 정보를 JS 전역(window.__ME__)으로 주입합니다.
+         - ForumController에서 model.addAttribute("me", ...)로 설정한 값을 직렬화합니다.
+         - main.js에서 댓글 입력창 아바타 바인딩에 사용됩니다. -->
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        window.__ME__ = /*[[${me}]]*/ null;
+        /*]]>*/
+    </script>
+
     <script defer th:src="@{/js/bundle.js}"></script>
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/main.css}">


### PR DESCRIPTION
## 구현 내용 요약
- Forum 댓글 입력창(모달)에서 아바타가 글 작성자 사진으로 표시되던 문제 수정
- 로그인 사용자(me) 프로필 사진을 우선 바인딩하도록 로직 개선
- DB 변경 없음, 화면/컨트롤러/JS만 수정

---

## 관련 이슈
Closes #141  
Refs #27

---

## 작업 상세 내역
- `ForumController.forumPage(Model, @AuthenticationPrincipal)`  
  - 로그인 사용자 정보를 `me(id, nickname, profilePhotoUrl)`로 모델에 주입
- `templates/forum/main.html`  
  - `<head>`에 `th:inline="javascript"` 스크립트 추가하여 `window.__ME__ = /*[[${me}]]*/` 전역 주입
- `src/main/js/pages/main.js`  
  - `openCommentModal(postId, postCard)` 내 댓글 입력창 아바타 `<img id="comment-editor-avatar">` 추가  
  - 아바타 바인딩을 `window.__ME__.profilePhotoUrl` 우선 → 없으면 `postData.writerProfilePhotoUrl`로 폴백
- 수동 테스트  
  - `npm run build` 후 강력 새로고침으로 캐시 무효화

---

## from to
<fix/cmt-avatar> -> <main>

---
