### PR TITLE
[수정] 알림센터 UI/UX 개선 및 무한 스크롤 적용 #144

### DIFF
--- a/src/main/java/io/github/nokasegu/post_here/notification/controller/NotificationApiController.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/controller/NotificationApiController.java
@@ -1,4 +1,3 @@
-// src/main/java/io/github/nokasegu/post_here/notification/controller/NotificationApiController.java
 package io.github.nokasegu.post_here.notification.controller;
 
 import io.github.nokasegu.post_here.notification.dto.MarkReadRequestDto;
@@ -59,6 +58,8 @@ public class NotificationApiController {
         Long me = resolveUserId(principal);
         int page = (body == null) ? 0 : body.safePage();
         int size = (body == null) ? 20 : body.safeSize();
+
+        // [변경] 서비스가 "FOLLOW 최신 1건만 + NULL 연결 제외 + 오버페치 + hasNext 계산"을 수행하여 반환
         return notificationService.list(me, page, size);
     }
 

--- a/src/main/java/io/github/nokasegu/post_here/notification/dto/NotificationListResponseDto.java
+++ b/src/main/java/io/github/nokasegu/post_here/notification/dto/NotificationListResponseDto.java
@@ -15,10 +15,30 @@ public class NotificationListResponseDto {
     private List<NotificationItemResponseDto> items;
     private long unreadCount;
 
+    // ===================== [신규] 페이지 메타 =====================
+    /**
+     * hasNext:
+     * - true  : 더 가져올 수 있는 알림이 남아있음
+     * - false : 이번 응답이 마지막 페이지(무한 스크롤 종료)
+     */
+    private Boolean hasNext;
+    // ============================================================
+
+    // [변경] 기존 팩토리 보존(하위 호환), hasNext가 null인 응답을 만들 때 사용 가능
     public static NotificationListResponseDto of(List<NotificationItemResponseDto> items, long unreadCount) {
         return NotificationListResponseDto.builder()
                 .items(items)
                 .unreadCount(unreadCount)
+                .hasNext(null) // [신규] 메타 제공이 없을 때는 null 유지 (프런트 휴리스틱 사용 가능)
+                .build();
+    }
+
+    // [신규] hasNext 포함 팩토리
+    public static NotificationListResponseDto of(List<NotificationItemResponseDto> items, long unreadCount, boolean hasNext) {
+        return NotificationListResponseDto.builder()
+                .items(items)
+                .unreadCount(unreadCount)
+                .hasNext(hasNext)
                 .build();
     }
 }

--- a/src/main/js/pages/notification.js
+++ b/src/main/js/pages/notification.js
@@ -6,29 +6,37 @@ export function initNotification() {
     // 이 페이지가 아니면 종료
     if (document.body?.id !== 'page-notifications') return;
 
+    // [신규] 웹뷰/브라우저의 자동 스크롤 복원 무력화 (최신 알림을 헤더 바로 밑에 보장)
+    try {
+        if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    } catch {
+    }
+
     let readAllOnce = false;
 
     const $list = document.querySelector('#list');
+    const $sentinel = document.getElementById('noti-sentinel'); // [신규] 무한 스크롤 센티넬
 
     if (!$list) {
         console.warn('[notification] 알림 리스트 요소를 찾지 못했습니다.');
         return;
     }
 
-    function syncFooterHeightVar() {
+    function syncLayoutVars() {
         try {
-            const nav = document.querySelector('.main-nav-bar');
-            const h = nav ? Math.ceil(nav.getBoundingClientRect().height) : 0;
-            const px = (h && Number.isFinite(h)) ? `${h}px` : null;
-            if (px) document.documentElement.style.setProperty('--footer-height', px);
+            const navBar = document.querySelector('.main-nav-bar');   // 하단 바 전체
+            const hNav = navBar ? Math.ceil(navBar.getBoundingClientRect().height) : 0;
+            const navPx = (hNav && Number.isFinite(hNav)) ? `${hNav}px` : null;
+            if (navPx) document.documentElement.style.setProperty('--footer-height', navPx);
+            // 상단은 헤더 고정이므로 별도 계산 필요 없음(헤더 높이로 CSS가 padding-top 계산)
         } catch { /* ignore */
         }
     }
 
-    syncFooterHeightVar();
-    setTimeout(syncFooterHeightVar, 300);
-    window.addEventListener('resize', syncFooterHeightVar);
-    window.addEventListener('orientationchange', syncFooterHeightVar);
+    syncLayoutVars();
+    setTimeout(syncLayoutVars, 300);
+    window.addEventListener('resize', syncLayoutVars);
+    window.addEventListener('orientationchange', syncLayoutVars);
 
     const API_BASE = '/api/notifications';
 
@@ -76,92 +84,160 @@ export function initNotification() {
         window.addEventListener('beforeunload', hide, {once: true});
     }
 
-    function render(items = []) {
-        $list.innerHTML = '';
-        if (!items.length) {
-            const empty = document.createElement('div');
-            empty.className = 'empty';
-            empty.textContent = '새 알림이 없습니다.';
-            $list.appendChild(empty);
-            return;
+    // === 문구 한글 통일: 타입별 맵핑 ===
+    function koreanMessageOf(it) {
+        // 가능한 코드 값: FOLLOW, FORUM_COMMENT, COMMENT, etc.
+        const code = (it.type ?? it.notificationCode ?? it.code ?? '').toUpperCase();
+        if (code === 'FOLLOW') {
+            return '님이 회원님을 팔로우하기 시작했습니다';
+        }
+        if (code === 'FORUM_COMMENT' || code === 'COMMENT') {
+            return '님이 회원님의 Forum에 댓글을 남겼습니다';
+        }
+        // 알 수 없는 타입은 서버 메시지 사용(최후의 보루)
+        return (it.text ?? it.message ?? (code || '')) || '';
+    }
+
+    // 렌더 한 건
+    function renderOne(it) {
+        const id = it.id ?? it.notificationId ?? it.notification_pk ?? null;
+        const actorNick = it.actor?.nickname ?? it.followerNickname ?? it.actor?.name ?? it.follower?.nickname ?? it.following?.follower?.nickname ?? '';
+        const avatarUrl = it.actor?.profilePhotoUrl ?? it.followerProfilePhotoUrl ?? '/images/profile-default.png';
+        const createdAt = it.createdAt ?? it.created_at ?? null;
+        const read = (typeof it.read === 'boolean') ? it.read
+            : (typeof it.checkStatus === 'boolean') ? it.checkStatus
+                : (typeof it.checked === 'boolean') ? it.checked : false;
+
+        // 댓글 알림 링크 우선, 없으면 프로필
+        const link = it.link || (actorNick ? `/profile/${encodeURIComponent(actorNick)}` : '#');
+
+        const row = document.createElement('a');
+        row.className = 'noti-card';
+        if (id != null) row.dataset.id = String(id);
+        row.href = link;
+        row.dataset.unread = String(!read);
+
+        const img = document.createElement('img');
+        img.className = 'noti-avatar';
+        img.alt = actorNick ? `${actorNick} profile` : 'profile';
+        img.src = avatarUrl || '/images/profile-default.png';
+        img.onerror = () => {
+            img.src = '/images/profile-default.png';
+        };
+        row.appendChild(img);
+
+        const main = document.createElement('div');
+        main.className = 'noti-main';
+
+        const head = document.createElement('div');
+        head.className = 'noti-head';
+
+        const nickEl = document.createElement('span');
+        nickEl.className = 'noti-nick';
+        // @ 제거
+        nickEl.textContent = actorNick || '(알 수 없음)';
+
+        const timeEl = document.createElement('span');
+        timeEl.className = 'noti-time';
+        timeEl.textContent = timeAgo(createdAt);
+
+        head.appendChild(nickEl);
+        head.appendChild(timeEl);
+
+        const actionEl = document.createElement('div');
+        actionEl.className = 'noti-action';
+        actionEl.textContent = koreanMessageOf(it);
+
+        main.appendChild(head);
+        main.appendChild(actionEl);
+
+        if (it.commentPreview) {
+            const pv = document.createElement('div');
+            pv.className = 'noti-preview';
+            pv.textContent = String(it.commentPreview);
+            main.appendChild(pv);
         }
 
+        row.appendChild(main);
+        return row;
+    }
+
+    // [신규] 중복 방지용 Set (페이지 경계 중복 안전)
+    const seenIds = new Set();
+
+    // 누적 렌더
+    function append(items = []) {
+        if (!items.length) return;
         const frag = document.createDocumentFragment();
-
-        items.forEach((it) => {
-            const id = it.id ?? it.notificationId ?? it.notification_pk ?? null;
-            const code = it.type ?? it.notificationCode ?? it.code ?? 'NOTI';
-            const text = it.text ?? it.message ?? (code === 'FOLLOW' ? 'Started following you' : code);
-            const actorNick = it.actor?.nickname ?? it.followerNickname ?? it.actor?.name ?? it.follower?.nickname ?? it.following?.follower?.nickname ?? '';
-            const avatarUrl = it.actor?.profilePhotoUrl ?? it.followerProfilePhotoUrl ?? '/images/profile-default.png';
-            const createdAt = it.createdAt ?? it.created_at ?? null;
-            const read = (typeof it.read === 'boolean') ? it.read : (typeof it.checkStatus === 'boolean') ? it.checkStatus : (typeof it.checked === 'boolean') ? it.checked : false;
-
-            // ===================== [변경] 링크 우선순위 =====================
-            // - 댓글 알림(COMMENT)에는 백엔드가 내려준 link(/forum/{id})가 존재
-            // - FOLLOW 등 기존 규칙은 프로필로 이동
-            const link = it.link || (actorNick ? `/profile/${encodeURIComponent(actorNick)}` : '#');
-
-            const row = document.createElement('a');
-            row.className = 'noti-card';
-            if (id != null) row.dataset.id = String(id);
-            row.href = link; // [변경] it.link 우선
-            row.setAttribute('aria-label', actorNick ? `${actorNick} ${text}` : text);
-            row.dataset.unread = String(!read);
-
-            const img = document.createElement('img');
-            img.className = 'noti-avatar';
-            img.alt = actorNick ? `${actorNick} profile` : 'profile';
-            img.src = avatarUrl || '/images/profile-default.png';
-            img.onerror = () => {
-                img.src = '/images/profile-default.png';
-            };
-            row.appendChild(img);
-
-            const main = document.createElement('div');
-            main.className = 'noti-main';
-            const head = document.createElement('div');
-            head.className = 'noti-head';
-            const nickEl = document.createElement('span');
-            nickEl.className = 'noti-nick';
-            nickEl.textContent = actorNick ? `@${actorNick}` : '(알 수 없음)';
-            const timeEl = document.createElement('span');
-            timeEl.className = 'noti-time';
-            timeEl.textContent = timeAgo(createdAt);
-            head.appendChild(nickEl);
-            head.appendChild(timeEl);
-            const textEl = document.createElement('div');
-            textEl.className = 'noti-text';
-            textEl.textContent = String(text);
-            main.appendChild(head);
-            main.appendChild(textEl);
-
-            // ===================== [신규] 댓글 미리보기(2줄 클램프) =====================
-            if (it.commentPreview) {
-                const pv = document.createElement('div');
-                pv.className = 'noti-preview'; // CSS에서 2줄 line-clamp
-                pv.textContent = String(it.commentPreview);
-                main.appendChild(pv);
-            }
-            // ========================================================================
-
-            row.appendChild(main);
-            frag.appendChild(row);
-        });
+        for (const it of items) {
+            const nid = it.id ?? it.notificationId ?? it.notification_pk;
+            if (nid != null && seenIds.has(nid)) continue; // [신규] 중복 스킵
+            if (nid != null) seenIds.add(nid);
+            frag.appendChild(renderOne(it));
+        }
         $list.appendChild(frag);
     }
 
-    async function load() {
+    // === 무한 스크롤 ===
+    let page = 0;
+    const size = 30;                      // 선로딩 강화
+    let loading = false;
+    let done = false;
+
+    async function loadNext() {
+        if (loading || done) return;
+        loading = true;
         try {
-            const data = await postJson(`${API_BASE}/list`, {page: 0, size: 100});
+            const data = await postJson(`${API_BASE}/list`, {page, size});
+            // 서버 DTO: { items: [...], unreadCount: N } (페이지 메타 없음)
             const items = Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : [];
 
-            render(items);
+            if (page === 0 && !items.length) {
+                $list.innerHTML = '';
+                const empty = document.createElement('div');
+                empty.className = 'empty';
+                empty.textContent = '새 알림이 없습니다.';
+                $list.appendChild(empty);
+                done = true;
+                // 첫 진입에 아무것도 없어도 스크롤 0 보정
+                requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(0, 0)));
+                return;
+            }
+
+            append(items);
+            page += 1;
+
+            // [중요] 초기 진입 직후 헤더 바로 밑에서 시작하도록 2-frame 보정
+            if (page === 1) {
+                requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(0, 0)));
+            }
+
+            // hasNext가 응답에 없으므로 휴리스틱:
+            //  - hasNext(명시) => 신뢰
+            //  - 없으면 items.length > 0인 동안 계속 로드, 빈 배열 받으면 종료
+            const respHasNext = (typeof data?.hasNext === 'boolean')
+                ? data.hasNext
+                : (typeof data?.pageInfo?.hasNext === 'boolean')
+                    ? data.pageInfo.hasNext
+                    : undefined;
+
+            if (respHasNext === true) {
+                // 계속
+            } else if (respHasNext === false) {
+                done = true;
+                if ($sentinel) $sentinel.style.display = 'none';
+            } else {
+                // 메타가 없으면 '빈 배열 나올 때까지' 계속
+                if (items.length === 0) {
+                    done = true;
+                    if ($sentinel) $sentinel.style.display = 'none';
+                }
+            }
 
             if (!readAllOnce) {
                 readAllOnce = true;
                 try {
-                    await postJson('/notification', {});
+                    await postJson('/notification', {}); // 기존 엔드포인트 유지
                     attachLeaveHandlersOnce();
                 } catch (e) {
                     console.debug('[notification] read-all failed:', e?.message || e);
@@ -169,10 +245,25 @@ export function initNotification() {
             }
         } catch (e) {
             console.error('[notification] load failed:', e?.message || e);
-            render([]);
+        } finally {
+            loading = false;
         }
     }
 
+    if ($sentinel && 'IntersectionObserver' in window) {
+        const io = new IntersectionObserver((entries) => {
+            for (const ent of entries) {
+                if (ent.isIntersecting) loadNext();
+            }
+        }, {root: null, rootMargin: '1000px 0px', threshold: 0}); // 넉넉한 선로딩
+        io.observe($sentinel);
+    } else {
+        window.addEventListener('scroll', () => {
+            const nearBottom = window.innerHeight + window.scrollY >= document.body.offsetHeight - 800;
+            if (nearBottom) loadNext();
+        });
+    }
+
     // 최초 로드
-    load();
+    loadNext();
 }

--- a/src/main/resources/static/css/notification.css
+++ b/src/main/resources/static/css/notification.css
@@ -1,197 +1,157 @@
-/* ===== Notification page styles ===== */
-
-/* 네비 높이 기본값(안전치) + 페이저 상하 대칭 간격 */
+/* ===== 공통 변수 ===== */
 :root {
-    --footer-height: 120px; /* JS가 실측으로 덮어씀 */
-    --pager-gap: 16px; /* 마지막 카드↔페이저 간격 = 페이저 상단 간격 */
-
-    --pager-height: 40px; /* 페이저의 높이를 변수로 정의 */
-
-    /* 빨간 점 위치/크기/간격(프로필과 1글자 정도 떨어지도록) */
-    --dot-left: 8px; /* 카드 왼쪽에서 점까지 */
-    --dot-size: 8px; /* 점 지름 */
-    --dot-gap: 8px; /* 점과 아바타 사이 간격(≈ 1글자) */
+    --noti-header-h: 56px; /* [신규] 헤더 높이 변수 */
+    --page-side-padding: 16px; /* [신규] 페이지 좌우 기본 여백 */
 }
 
-/* 이 페이지에서 전역 flex 영향 제거 + 가로 스크롤 방지 + 배경 흰색(양옆 띠 제거) */
-#page-notifications {
-    display: flex;
-    justify-content: center;
-    background-color: #f0f2f5;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    width: 100%;
-    min-height: 100%;
-    overflow-x: hidden;
-    overflow-y: hidden;
+/* [신규] 이 페이지에서 app-container의 기본 중앙정렬을 덮어써서 '리스트 화면' 레이아웃로 전환 */
+#page-notifications #app-container {
+    justify-content: flex-start; /* [신규] 위에서부터 쌓이도록 */
+    align-items: stretch; /* [신규] 가로는 꽉 채움 */
 }
 
-
-/* ===== 상단바 ===== */
-.noti-topbar {
-    display: flex;
-    justify-content: center; /* 가운데 타이틀을 위한 중앙 정렬 */
-    align-items: center;
-    height: 35px;
-    background: #fff;
-    border-bottom: 1px solid #e9e9e9;
-    position: sticky;
+/* ===== 상단 헤더 ===== */
+.noti-topbar { /* (유지) fixed 헤더 */
+    position: fixed;
     top: 0;
-    z-index: 1000;
-    width: 100%;
-    padding: 10px 0;
+    left: 0;
+    right: 0;
+    height: var(--noti-header-h);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--page-side-padding);
+    background: #fff;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    z-index: 100;
 }
 
 .noti-title {
+    font-size: 18px;
+    font-weight: 800;
     margin: 0;
-    font-size: 18px;
-    font-weight: 700;
-    line-height: 1;
+    color: #111;
 }
 
-.noti-back-btn {
-    position: absolute;
-    left: 8px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 36px;
-    height: 36px;
-    border: 0;
-    background: transparent;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 18px;
-    color: #333;
-}
-
-/* ===== 리스트 ===== */
-#page-notifications .list {
-    width: 100%;
-    max-width: 360px;
-    margin: 0 auto;
-    padding: 8px 12px 0; /* ← 하단 패딩 제거: 마지막 카드와 페이저 간격은 pager의 margin-top으로만 제어 */
-    box-sizing: border-box;
+/* ===== 리스트 래퍼 ===== */
+.list {
+    /* [변경] 헤더 '바로 밑'부터 시작: 헤더 높이 + 8px */
+    padding-top: calc(var(--noti-header-h) + 8px) !important;
+    /* [변경] 하단은 footer 높이 + 4px만 부여(여백 최소화). 전부 로드되어도 값 고정 → 바닥이 딱 붙어 보임 */
+    padding-bottom: calc(var(--footer-height, 0px) + 4px);
+    padding-left: 0;
+    padding-right: 0;
     background: #fff;
-    border-left: 0;
-    border-right: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    min-height: calc(100% - 48px - var(--footer-height));
-    overflow-y: auto;
-    flex-grow: 1;
+    position: relative;
 }
 
-/* 비었을 때 */
-#page-notifications .list .empty {
-    padding: 24px 12px;
-    color: #999;
-    text-align: center;
-}
-
-/* ===== 카드 ===== */
-/* a 요소 자체를 카드로 사용 */
-.noti-card {
-    position: relative; /* 빨간 점 의사요소 위치 기준 */
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 12px 6px;
-    border-bottom: 1px solid #eee;
-    text-decoration: none;
-    color: inherit;
-
-    /* 빨간 점 칼럼을 항상 예약 → 점 유무와 무관하게 정렬 고정 */
-    padding-left: calc(var(--dot-left) + var(--dot-size) + var(--dot-gap));
-}
-
-/* 링크 파란색/밑줄 제거(모든 상태) */
-a.noti-card,
-a.noti-card:link,
-a.noti-card:visited,
-a.noti-card:hover,
-a.noti-card:active {
-    color: inherit;
-    text-decoration: none;
-}
-
-/* 빨간 점: 의사요소. data-unread="true"일 때만 채워짐 */
-.noti-card::before {
+/* [신규] 보이지 않는 1px 스페이서: 여백은 없지만 바닥에서 살짝 '움찔/글로우'가 남도록 */
+.list::after {
     content: "";
-    position: absolute;
-    left: var(--dot-left);
-    top: 50%;
-    transform: translateY(-50%);
-    width: var(--dot-size);
-    height: var(--dot-size);
-    border-radius: 9999px;
-    background: transparent;
+    display: block;
+    height: 1px;
 }
 
-.noti-card[data-unread="true"]::before {
-    background: #e74c3c;
+/* ===== 카드(알림 한 줄) ===== */
+/* [중요] 좌우 여백은 **항상 동일**. 빨간 점 유무와 무관하게 padding 고정. */
+.noti-card {
+    position: relative; /* 빨간 점 절대배치용 */
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px var(--page-side-padding) 14px 28px; /* 좌:28, 우:16 → 항상 동일 */
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    background: #fff;
 }
 
-/* 프로필 이미지(원형, 전역 규칙 무력화) */
-#page-notifications .noti-card .noti-avatar {
-    width: 42px;
-    height: 42px;
+.list .noti-card:first-child {
+    margin-top: 0 !important;
+}
+
+/* 프로필 아바타 */
+.noti-avatar {
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     object-fit: cover;
-    flex: 0 0 42px;
-    display: block;
-    max-width: none;
-    max-height: none;
-    aspect-ratio: 1 / 1;
+    flex: 0 0 44px;
 }
 
-/* 본문 래퍼 */
+/* 본문 */
 .noti-main {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
     flex: 1 1 auto;
+    min-width: 0;
 }
 
-/* 1줄: 닉네임 + 시간(같은 줄, 오른쪽 끝 정렬 아님) */
+/* 닉네임 + 시간 (시간은 닉네임 오른쪽에 "2글자" 간격) */
 .noti-head {
     display: flex;
     align-items: baseline;
-    gap: 8px; /* 닉네임과 시간 사이 1~2글자 간격 */
+    gap: 0;
+    margin-bottom: 4px;
 }
 
 .noti-nick {
-    font-weight: 700;
+    font-weight: 800;
+    font-size: 15px;
+    line-height: 1.3;
+    color: #111;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: 70%;
 }
 
 .noti-time {
-    flex: none; /* 자동 우측 밀림 방지 */
     font-size: 12px;
-    color: #999;
+    color: #9ca3af;
+    margin-left: 2ch; /* [변경] 시각을 닉네임 옆에 */
+    flex: 0 0 auto;
 }
 
-/* 2줄: 메시지 */
-.noti-text {
-    color: #555;
-    line-height: 1.3;
-    word-break: break-word;
+/* 액션 문구(회색) */
+.noti-action {
+    font-size: 14px;
+    line-height: 1.45;
+    color: #6b7280;
 }
 
+/* 댓글 미리보기(최대 2줄 + …) */
 .noti-preview {
+    margin-top: 4px;
+    font-size: 14px;
+    color: #374151;
     display: -webkit-box;
-    -webkit-line-clamp: 2; /* 2줄 클램프 */
+    -webkit-line-clamp: 2; /* 2줄 제한 */
     -webkit-box-orient: vertical;
     overflow: hidden;
-    word-break: break-word;
-    margin-top: 2px;
-    font-size: 0.94rem; /* 본문보다 살짝 작게 */
-    line-height: 1.32;
-    opacity: 0.9;
+    word-break: break-word; /* 자연스러운 줄바꿈(긴 단어/URL 대응) */
+    overflow-wrap: anywhere; /* 강제 줄바꿈 허용 */
+    /* -webkit-line-clamp 사용 시 크롬/웹뷰에 기본 말줄임(…) 표시 */
+}
+
+/* [중요 유지] 빨간 점은 **색상만** 토글. 레이아웃 영향 0. */
+.noti-card::before {
+    content: "";
+    position: absolute;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    left: 12px; /* 카드 왼쪽 내부 고정 좌표 */
+    top: calc(14px + 22px - 4px); /* 패딩(14)+아바타중앙(22)-반지름(4) */
+    background: transparent; /* 읽음(기본): 투명 */
+}
+
+.noti-card[data-unread="true"]::before {
+    background: #ef4444; /* 미읽음: 빨간 점 표시 */
+}
+
+/* 빈 상태 */
+.empty {
+    padding: 32px var(--page-side-padding);
+    color: #6b7280;
+    text-align: center;
+    font-size: 14px;
 }

--- a/src/main/resources/templates/notification/notification.html
+++ b/src/main/resources/templates/notification/notification.html
@@ -24,12 +24,16 @@
 <div id="app-container">
 
     <!-- 상단바: 좌측 뒤로가기 + 가운데 타이틀 -->
+    <!-- [변경] fixed 헤더 유지: 최신 알림이 '헤더 바로 밑'에 보이도록 CSS 상단 패딩을 헤더 높이로만 부여 -->
     <header class="noti-topbar">
         <h2 class="noti-title">알림</h2>
     </header>
 
     <!-- 알림 목록 컨테이너: notification.js가 innerHTML로 카드 목록 렌더링 -->
     <div aria-live="polite" class="list" id="list"></div>
+
+    <!-- [신규] 무한 스크롤 관찰용 센티넬 -->
+    <div aria-hidden="true" id="noti-sentinel"></div>
 
     <div th:replace="~{fragment/main-nav :: mainNavFragment}"></div>
 </div>


### PR DESCRIPTION
## 구현 내용 요약
- 최신 알림이 **헤더 바로 밑**에 항상 보이도록 레이아웃 수정
- 무한 스크롤 안정화: 자동 스크롤 복원 무력화, hasNext 지원, 중복 제거
- FOLLOW 알림은 **팔로워별 최신 1건만** 노출 + 끊긴 FOLLOW(ON DELETE SET NULL) **제외**
- 응답 DTO에 **hasNext** 추가
- 알림 카드 UX 개선: 문구 한글 통일, 댓글 미리보기(2줄 + …), 빨간 점 토글로 정렬 유지

---

## 관련 이슈
Closes #144  
Closes #103

---

## 작업 상세 내역
- **서버**
  - `NotificationService`: 서비스 후처리 추가  
    - FOLLOW: `following == null` 제외, `followerId`별 **최신 1건만** 허용  
    - **오버페치** 후 필터링 → 요청 size로 슬라이스, **hasNext** 계산
  - `NotificationListResponseDto`: `Boolean hasNext` 필드 및 팩토리 추가
  - `NotificationApiController`: 목록 응답에 서비스의 hasNext 전달(시그니처 유지)
- **프런트**
  - `notification.html`: 고정 헤더 유지, 센티넬 배치
  - `notification.css`: 리스트 상단 패딩을 **헤더 높이 + 8px**로 고정, 바닥 **1px 스페이서**로 여백 없이 ‘움찔’ 유지, 댓글 미리보기 2줄 말줄임
  - `notification.js`:
    - `history.scrollRestoration='manual'` + 2×`requestAnimationFrame` 후 `scrollTo(0)`로 **최신 알림을 헤더 바로 밑**에 고정
    - `hasNext`가 있으면 신뢰, 없으면 **빈 배열 나올 때까지** 로드
    - `seenIds(Set)`로 페이지 경계 **중복 제거**
    - 한글 문구 통일(FOLLOW/COMMENT), '@' 제거, 시간은 닉네임 옆 **2ch 간격**

---

## from to
<fix/notification-ui-ux> -> <main>

---