### PR TITLE
[feat]: 포럼 기능 개선 및 모바일 UI/UX 최적화

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,11 +10,12 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-preferences')
+    implementation project(':capacitor-push-notifications')
+    implementation project(':capacitor-status-bar')
     implementation project(':transistorsoft-capacitor-background-fetch')
     implementation project(':transistorsoft-capacitor-background-geolocation')
-    implementation project(':capacitor-local-notifications')
-    implementation project(':capacitor-push-notifications')
 
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
                 android:label="@string/title_activity_main"
                 android:exported="true"
                 android:launchMode="singleTask"
-                android:theme="@style/AppTheme.NoActionBarLaunch"
+                android:theme="@style/AppTheme.NoActionBar"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation">
 
             <intent-filter>

--- a/android/app/src/main/java/com/nokasegu/post_here/MainActivity.java
+++ b/android/app/src/main/java/com/nokasegu/post_here/MainActivity.java
@@ -1,5 +1,32 @@
 package com.nokasegu.post_here;
 
+import android.os.Build;
+import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // [최종 해결책] Activity 시작 시 Android 시스템에 상태 표시줄 스타일을 강제 설정
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            // Activity가 시스템 UI(상태 표시줄)와 상호작용할 수 있도록 설정
+            WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+            // 1. 상태 표시줄 배경을 투명하게 설정합니다. (styles.xml과 일치)
+            getWindow().setStatusBarColor(android.graphics.Color.TRANSPARENT);
+
+            // 2. [핵심 수정] WindowInsetsControllerCompat을 사용하여 아이콘 스타일을 강제합니다.
+            WindowInsetsControllerCompat windowInsetsController =
+                    WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+
+            if (windowInsetsController != null) {
+                // Style.Dark에 해당: 상태 표시줄 아이콘을 어둡게 설정합니다.
+                windowInsetsController.setAppearanceLightStatusBars(true);
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,17 +2,24 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+
+        <item name="android:statusBarColor">@android:color/transparent</item>
+
+        <item name="android:windowLightStatusBar">true</item>
     </style>
 
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,17 +5,20 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-local-notifications'
+project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
+
 include ':capacitor-preferences'
 project(':capacitor-preferences').projectDir = new File('../node_modules/@capacitor/preferences/android')
+
+include ':capacitor-push-notifications'
+project(':capacitor-push-notifications').projectDir = new File('../node_modules/@capacitor/push-notifications/android')
+
+include ':capacitor-status-bar'
+project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
 
 include ':transistorsoft-capacitor-background-fetch'
 project(':transistorsoft-capacitor-background-fetch').projectDir = new File('../node_modules/@transistorsoft/capacitor-background-fetch/android')
 
 include ':transistorsoft-capacitor-background-geolocation'
 project(':transistorsoft-capacitor-background-geolocation').projectDir = new File('../node_modules/@transistorsoft/capacitor-background-geolocation/android')
-
-include ':capacitor-local-notifications'
-project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
-
-include ':capacitor-push-notifications'
-project(':capacitor-push-notifications').projectDir = new File('../node_modules/@capacitor/push-notifications/android')

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/local-notifications": "^7.0.3",
         "@capacitor/preferences": "^7.0.2",
         "@capacitor/push-notifications": "^7.0.3",
+        "@capacitor/status-bar": "^7.0.3",
         "@transistorsoft/capacitor-background-fetch": "^7.1.0",
         "@transistorsoft/capacitor-background-geolocation": "^7.2.2"
       },
@@ -1627,6 +1628,15 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-7.0.3.tgz",
       "integrity": "sha512-4qt5dRVBkHzq202NEoj3JC+S+zQCrZ1FJh7sjkICy/i1iEos+VaoB3bie8eWDQ2LTARktB4+k2xkdpu8pcVo/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.3.tgz",
+      "integrity": "sha512-JyRpVnKwHij9hgPWolF6PK+HT3e2HSPjN11/h2OmKxq8GAdPGARFLv+97eZl0pvuvm0Kka/LpiLb5whXISBg7Q==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "@capacitor/app": "^7.1.0",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
-    "@capacitor/preferences": "^7.0.2",
-    "@transistorsoft/capacitor-background-fetch": "^7.1.0",
-    "@transistorsoft/capacitor-background-geolocation": "^7.2.2",
     "@capacitor/local-notifications": "^7.0.3",
-    "@capacitor/push-notifications": "^7.0.3"
+    "@capacitor/preferences": "^7.0.2",
+    "@capacitor/push-notifications": "^7.0.3",
+    "@capacitor/status-bar": "^7.0.3",
+    "@transistorsoft/capacitor-background-fetch": "^7.1.0",
+    "@transistorsoft/capacitor-background-geolocation": "^7.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
+++ b/src/main/java/io/github/nokasegu/post_here/forum/controller/ForumImageController.java
@@ -27,7 +27,7 @@ public class ForumImageController {
         List<String> imageUrls = images.stream()
                 .map(image -> {
                     try {
-                        // ★★★ 변경: S3에 업로드만 하고 URL을 반환합니다. ★★★
+                        // S3에 업로드만 하고 URL을 반환
                         return forumImageService.uploadImage(image);
                     } catch (IOException e) {
                         throw new RuntimeException("이미지 업로드 중 오류가 발생했습니다.", e);

--- a/src/main/js/modules/main-nav.js
+++ b/src/main/js/modules/main-nav.js
@@ -4,11 +4,27 @@
  * - 미읽음 배지 갱신(단일 엔드포인트)
  * - SW NAVIGATE 메시지(있으면) 처리
  */
+import {Preferences} from '@capacitor/preferences';
 import {authHeaders} from './utils.js';
 
 export function initMainNav() {
     const navLinks = document.querySelectorAll('.footer-nav a');
     const currentPath = window.location.pathname;
+
+    function showToast(message) {
+        const toast = document.getElementById("toast");
+        if (!toast) {
+            console.warn("Toast container not found.");
+            return;
+        }
+        const messageEl = toast.querySelector('.toast-message');
+        messageEl.textContent = message;
+        toast.classList.add("show");
+
+        setTimeout(() => {
+            toast.classList.remove("show");
+        }, 1500);
+    }
 
     // ===== 기존 활성화 로직 유지 =====
     navLinks.forEach(link => {
@@ -28,13 +44,6 @@ export function initMainNav() {
         const homeLink = document.querySelector('.footer-nav a[href="/forumMain"]');
         if (homeLink) homeLink.classList.add('active');
     }
-
-    navLinks.forEach(link => {
-        link.addEventListener('click', (e) => {
-            navLinks.forEach(item => item.classList.remove('active'));
-            e.currentTarget.classList.add('active');
-        });
-    });
 
     // ===== 1. 사각형 토글 기능 =====
     const toggleButton = document.getElementById('toggle-button');
@@ -67,11 +76,38 @@ export function initMainNav() {
     }
 
     // 토글 항목 클릭 시 해당 경로로 이동 (클릭 이벤트 추가)
-    const toggleItems = document.querySelectorAll('.toggle-item'); // ▼▼▼ [수정됨] toggle-item 참조
+    const toggleItems = document.querySelectorAll('.toggle-item');
     toggleItems.forEach(item => {
-        item.addEventListener('click', (e) => {
+        item.addEventListener('click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+
             // 클릭한 항목의 href를 가져와 페이지 이동
             const href = item.getAttribute('href');
+
+            // 포럼 작성 버튼(/forum) 클릭 시 유효성 검사
+            if (href === '/forum') {
+                // 1. GPS 추적 위치 키 (실제 위치)
+                const {value: actualAreaKey} = await Preferences.get({key: 'currentAreaKey'});
+                // 2. 현재 메인 페이지에서 보고 있는 지역 키 (URL 또는 Preferences에서 가져온 값)
+                const {value: viewingAreaKey} = await Preferences.get({key: 'viewingAreaKey'});
+
+                // 필수 키가 없는 경우 (GPS가 잡히지 않았거나 초기 로드 오류)
+                if (!actualAreaKey || !viewingAreaKey) {
+                    showToast('위치 정보 설정이 불안정합니다. 잠시 후 다시 시도해 주세요.');
+                    toggleSquare(false);
+                    return;
+                }
+
+                // 두 키가 다른 경우 (다른 지역을 보고 있음)
+                if (actualAreaKey !== viewingAreaKey) {
+                    showToast('작성 가능한 지역이 아닙니다.');
+                    toggleSquare(false);
+                    return; // 이동 차단
+                }
+            }
+
+            // 모든 검증을 통과한 경우에만 수동으로 이동 처리
             if (href) {
                 location.href = href;
                 // 토글 닫기

--- a/src/main/js/pages/forum-edit.js
+++ b/src/main/js/pages/forum-edit.js
@@ -5,6 +5,9 @@ export function initForumEdit() {
     const submitButton = $('#submit-btn');
     const imagePreviewContainer = $('#image-preview-container');
 
+    const MAX_TEXT_LENGTH = 3000;
+    const textCountDisplay = document.getElementById('text-count-display');
+
     const originalContent = contentTextarea.val();
     const originalImageCount = imagePreviewContainer.find('.image-preview-wrapper').length;
 
@@ -28,18 +31,41 @@ export function initForumEdit() {
         imagePreviewContainer.addClass('has-image');
     }
 
+    // 텍스트 카운터 업데이트 함수
+    const updateTextCounter = () => {
+        const currentLength = contentTextarea.val().length;
+        textCountDisplay.textContent = `${currentLength}/${MAX_TEXT_LENGTH}`;
+
+        if (currentLength > MAX_TEXT_LENGTH) {
+            textCountDisplay.style.color = 'red';
+            // 버튼 비활성화는 updateSubmitButtonState가 처리
+        } else {
+            textCountDisplay.style.color = '#666';
+        }
+    };
+
     const updateSubmitButtonState = () => {
+        const currentContent = contentTextarea.val();
+        const currentLength = currentContent.length;
+
+        // 현재 텍스트 내용이 공백을 제외하고 1자 이상이며, 길이 제한을 넘지 않는지 확인
+        const isContentValid = currentContent.trim().length > 0 && currentLength <= MAX_TEXT_LENGTH;
+
         const contentChanged = contentTextarea.val() !== originalContent;
         const imageCountChanged = imagePreviewContainer.find('.image-preview-wrapper').length !== originalImageCount;
 
-        const hasChanges = contentChanged || imageCountChanged;
+        // 변경 사항이 있으면서 동시에 내용이 유효할 때만 버튼 활성화
+        const hasChangesAndValid = (contentChanged || imageCountChanged) && isContentValid;
 
-        if (hasChanges) {
+        if (hasChangesAndValid) {
             submitButton.prop('disabled', false);
         } else {
             submitButton.prop('disabled', true);
         }
     };
+
+    // 페이지 로드 시 카운터 초기화
+    updateTextCounter();
 
     $('#back-btn').on('click', function () {
         const contentChanged = contentTextarea.val() !== originalContent;
@@ -53,7 +79,21 @@ export function initForumEdit() {
         }
     });
 
-    contentTextarea.on('input', updateSubmitButtonState);
+    // 입력 시점에 텍스트 길이 제한을 넘는 텍스트가 들어오지 않도록 방지
+    contentTextarea.on('input', (e) => {
+        const currentLength = contentTextarea.val().length;
+
+        // 1. 길이 초과 시 입력 방지 및 경고
+        if (currentLength > MAX_TEXT_LENGTH) {
+            const trimmedValue = contentTextarea.val().substring(0, MAX_TEXT_LENGTH);
+            contentTextarea.val(trimmedValue);
+            showToast(`텍스트는 최대 ${MAX_TEXT_LENGTH}자까지만 입력할 수 있습니다.`);
+            return;
+        }
+        // 2. 카운터 및 버튼 상태 업데이트
+        updateTextCounter();
+        updateSubmitButtonState();
+    });
 
     imagePreviewContainer.on('click', '.delete-button', function () {
         const button = $(this);
@@ -77,10 +117,27 @@ export function initForumEdit() {
 
     updateSubmitButtonState();
 
-    forumForm.on('submit', async function (e) {
-        e.preventDefault();
+    submitButton.on('click', async function (e) {
+        e.preventDefault(); // 버튼의 기본 submit 동작을 항상 막습니다.
 
         const updatedContents = contentTextarea.val().trim();
+        const finalLength = updatedContents.length;
+
+        // 유효성 검사 분기 로직 (토스트를 띄우는 역할)
+        if (!updatedContents) {
+            // 텍스트가 공백이거나 0자일 때 showToast를 띄웁니다.
+            showToast('게시글 내용을 입력해주세요.');
+            return; // 제출 로직 실행 중단
+        }
+
+        if (finalLength > MAX_TEXT_LENGTH) {
+            showToast(`게시글 내용을 ${MAX_TEXT_LENGTH}자 이내로 입력해주세요.`);
+            return; // 제출 로직 실행 중단
+        }
+
+        // 버튼을 다시 비활성화하고 로딩 상태로
+        submitButton.prop('disabled', true);
+        submitButton.text('업데이트 중...');
 
         const requestBody = {
             content: updatedContents,
@@ -101,7 +158,6 @@ export function initForumEdit() {
 
             const result = await response.json();
             if (result.status === '000') {
-                // 수정 성공 시, 쿼리 파라미터를 추가하여 메인 페이지로 이동
                 window.location.href = `/forumMain?message=edit-success`;
             } else {
                 showToast('게시글 수정에 실패했습니다: ' + result.message);
@@ -109,6 +165,10 @@ export function initForumEdit() {
         } catch (error) {
             console.error('게시글 수정 오류:', error);
             showToast('게시글 수정 중 오류가 발생했습니다.');
+        } finally {
+            // 오류나 실패 시 버튼 상태 복구
+            submitButton.prop('disabled', false);
+            submitButton.text('완료');
         }
     });
 }

--- a/src/main/js/pages/forum-write.js
+++ b/src/main/js/pages/forum-write.js
@@ -1,4 +1,4 @@
-import {Preferences} from "@capacitor/preferences";
+import {Preferences} from '@capacitor/preferences';
 
 export function initForumWrite() {
 
@@ -13,14 +13,22 @@ export function initForumWrite() {
     const editorCloseBtn = document.getElementById('editor-close-btn');
     const editorDoneBtn = document.getElementById('editor-done-btn');
     const imageToCrop = document.getElementById('image-to-crop');
-    const imageCropperContainer = document.getElementById('image-cropper-container');
 
-    // 편집된 이미지 파일을 저장할 변수
-    let editedImageFile = null;
-    let originalImageFile = null;
+    // 최대 이미지 및 텍스트 개수 정의
+    const MAX_IMAGES = 10;
+    const MAX_TEXT_LENGTH = 3000;
+    const textCountDisplay = document.getElementById('text-count-display');
 
     // Cropper.js 인스턴스 저장 변수
     let cropperInstance;
+
+    // 최종적으로 서버에 전송될 편집 완료된 이미지 파일 배열
+    let finalImageFiles = [];
+    // 사용자가 새로 선택한, 아직 크롭을 거치지 않은 원본 파일 배열 (크롭 대기열)
+    let imagesToCropQueue = [];
+    // 현재 크롭 중인 파일
+    let currentFileBeingCropped = null;
+
 
     function showToast(message, callback) {
         const toast = document.getElementById("toast");
@@ -36,80 +44,177 @@ export function initForumWrite() {
         }, 1500);
     }
 
+    // 텍스트 카운터를 업데이트하는 함수
+    const updateTextCounter = () => {
+        if (!textCountDisplay) return;
+
+        const currentLength = contentInput.value.length;
+        textCountDisplay.textContent = `${currentLength}/${MAX_TEXT_LENGTH}`;
+
+        if (currentLength > MAX_TEXT_LENGTH) {
+            textCountDisplay.style.color = 'red';
+            // 버튼 비활성화는 'input' 리스너에서 처리
+        } else {
+            textCountDisplay.style.color = '#333';
+        }
+    };
+
+    // 이미지 버튼 활성화 상태 업데이트 함수
+    const updateImageButtonState = () => {
+        const currentCount = finalImageFiles.length;
+
+        // 이미지 추가 버튼 활성화/비활성화 제어
+        if (currentCount >= MAX_IMAGES) {
+            addImageButton.disabled = true;
+            addImageButton.classList.remove('active');
+        } else {
+            addImageButton.disabled = false;
+        }
+    };
+
     // 페이지 로드 시 버튼을 비활성화 상태로 설정
     submitButton.disabled = true;
+    updateTextCounter(); // 초기 카운터 표시
+    updateImageButtonState(); // 초기 이미지 버튼 상태 설정
 
-    // 사용자가 선택한 파일들을 저장할 배열
-    let selectedImageFiles = [];
-
-    // '이미지 추가' 버튼 클릭 시, 숨겨진 파일 input을 클릭합니다.
+    // '이미지 추가' 버튼 클릭 시, 숨겨진 파일 input을 클릭
     addImageButton.addEventListener('click', () => {
+        if (finalImageFiles.length >= MAX_IMAGES) {
+            showToast(`이미지는 최대 ${MAX_IMAGES}장까지만 업로드할 수 있습니다.`);
+            return;
+        }
         imageInput.click();
     });
 
-    // 파일 선택 시 Cropper.js 인스턴스 생성
+    // 파일 선택 시: 크롭 대기열에 추가하고 첫 번째 크롭 시작
     imageInput.addEventListener('change', (e) => {
-        const file = e.target.files[0];
-        if (file) {
-            originalImageFile = file;
-            const reader = new FileReader();
-            reader.onload = (e) => {
-                imageToCrop.src = e.target.result;
-                imageEditorOverlay.classList.add('show');
+        let newFiles = Array.from(e.target.files);
+        let spaceLeft = MAX_IMAGES - finalImageFiles.length; // 현재 남은 공간
 
-                // 기존의 cropper 인스턴스가 있으면 제거
-                if (cropperInstance) {
-                    cropperInstance.destroy();
-                }
+        // 10장 초과 파일 자르기 및 경고
+        if (newFiles.length > spaceLeft) {
+            newFiles = newFiles.slice(0, spaceLeft);
+            showToast(`최대 ${MAX_IMAGES}장까지만 가능하여 ${spaceLeft}장만 추가됩니다.`);
+        }
 
-                // Cropper.js 인스턴스 생성
-                cropperInstance = new Cropper(imageToCrop, {
-                    // 3:4 비율로 고정 (세로:가로)
-                    aspectRatio: 3 / 4,
-                    viewMode: 1, // 크롭 박스가 컨테이너를 벗어나지 않도록 설정
-                    dragMode: 'move', // 마우스로 이미지를 이동시킬 수 있도록 설정
-                    autoCropArea: 1, // 전체 이미지를 초기 크롭 영역으로 설정
-                    ready() {
-                        // 이미지 로드 후 축소/이동이 가능하도록 설정
-                        this.cropper.zoomTo(1);
-                    }
-                });
-            };
-            reader.readAsDataURL(file);
+        // 새 파일들을 크롭 대기열에 추가
+        imagesToCropQueue.push(...newFiles);
+
+        // 이미지 입력 필드 초기화 (동일 파일 재선택 가능하게)
+        e.target.value = '';
+
+        // 크롭 대기열에 이미지가 있고, 현재 크롭 중인 파일이 없으면 크롭 시작
+        if (imagesToCropQueue.length > 0 && !currentFileBeingCropped) {
+            processNextImageInQueue();
         }
     });
 
+    // 크롭 대기열에서 다음 이미지를 가져와 편집기를 엽니다.
+    function processNextImageInQueue() {
+        if (imagesToCropQueue.length === 0) {
+            currentFileBeingCropped = null;
+            redrawAllPreviews();
+            imageEditorOverlay.classList.remove('show'); // 마지막에 팝업 닫기
+            return;
+        }
+
+        // 큐에서 다음 파일을 꺼냅니다.
+        currentFileBeingCropped = imagesToCropQueue.shift();
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            imageToCrop.src = e.target.result;
+
+            // 편집기 팝업 표시
+            imageEditorOverlay.classList.add('show');
+            if (cropperInstance) {
+                cropperInstance.destroy();
+            }
+            // Cropper.js 인스턴스 생성
+            cropperInstance = new Cropper(imageToCrop, {
+                aspectRatio: 3 / 4, // 3:4 비율 고정
+                viewMode: 1,
+                dragMode: 'move',
+                autoCropArea: 1,
+                ready() {
+                    this.cropper.zoomTo(1);
+                }
+            });
+        };
+        reader.readAsDataURL(currentFileBeingCropped);
+    }
+
     // '다음' 버튼 클릭 시 크롭된 이미지 가져오기
     editorDoneBtn.addEventListener('click', () => {
-        if (!cropperInstance) return;
+        if (!cropperInstance || !currentFileBeingCropped) return;
 
         // 크롭된 이미지를 Blob 형태로 가져오기
         cropperInstance.getCroppedCanvas().toBlob((blob) => {
-            editedImageFile = new File([blob], `cropped_image_${Date.now()}.png`, {type: 'image/png'});
+            // 크롭된 새 파일 객체 생성 및 최종 배열에 추가
+            const editedFile = new File([blob], `cropped_image_${Date.now()}.jpeg`, {type: 'image/jpeg'});
+            finalImageFiles.push(editedFile);
 
-            imagePreviewContainer.innerHTML = '';
-            selectedImageFiles = [editedImageFile];
-            displayImagePreview(editedImageFile);
+            // 1. 팝업의 이미지를 크롭된 결과물로 교체 (렌더링 피드백)
+            const reader = new FileReader();
 
-            imageEditorOverlay.classList.remove('show');
-            imageInput.value = '';
-            cropperInstance.destroy(); // 크롭 인스턴스 제거
-            cropperInstance = null;
-        }, 'image/png', 0.9);
+            reader.onload = (e) => {
+                imageToCrop.src = e.target.result;
+
+                // 2. Cropper 인스턴스 파괴
+                if (cropperInstance) {
+                    cropperInstance.destroy();
+                }
+                currentFileBeingCropped = null; // 정리
+
+                // 3. DOM 강제 리플로우 (잔상 제거의 핵심!)
+                void imageEditorOverlay.offsetHeight;
+
+                // 4. 팝업을 즉시 닫고 다음 로직을 실행
+                imageEditorOverlay.classList.remove('show');
+                processNextImageInQueue();
+            };
+            reader.readAsDataURL(blob); // 비동기 로딩 시작
+
+        }, 'image/jpeg', 0.9);
     });
 
-    // 팝업 닫기 버튼에 크롭 인스턴스 제거 로직
+    // 팝업 닫기 버튼에 크롭 인스턴스 제거 로직 (편집 취소)
     editorCloseBtn.addEventListener('click', () => {
-        imageEditorOverlay.classList.remove('show');
-        imageInput.value = '';
+        // 현재 크롭 중이던 파일을 최종 배열에 추가하지 않고 버림
+
+        // 크롭 세션 종료
         if (cropperInstance) {
             cropperInstance.destroy();
             cropperInstance = null;
         }
+        currentFileBeingCropped = null;
+
+        imageEditorOverlay.classList.remove('show');
+
+        // 다음 이미지 크롭 시작
+        processNextImageInQueue();
     });
 
-    // 미리보기 이미지를 생성하는 함수로 분리
-    function displayImagePreview(file) {
+    // finalImageFiles 배열의 모든 파일을 기반으로 미리보기를 다시 그림
+    function redrawAllPreviews() {
+        imagePreviewContainer.innerHTML = ''; // 기존 미리보기 모두 제거
+        finalImageFiles.forEach(file => displaySingleImagePreview(file));
+
+        if (finalImageFiles.length === 0) {
+            addImageButton.classList.remove('active');
+            imagePreviewContainer.classList.remove('has-image');
+        } else {
+            addImageButton.classList.add('active');
+            imagePreviewContainer.classList.add('has-image');
+        }
+
+        // 이미지 버튼 상태 업데이트 호출
+        updateImageButtonState();
+
+    }
+
+    // 미리보기 이미지를 생성하고 삭제 버튼을 연결하는 함수
+    function displaySingleImagePreview(file) {
         const reader = new FileReader();
         reader.onload = (e) => {
             const previewWrapper = document.createElement('div');
@@ -119,16 +224,26 @@ export function initForumWrite() {
             img.src = e.target.result;
             img.classList.add('img-preview');
 
+            // 미리보기 클릭 시 재편집 기능 (옵션)
+            img.addEventListener('click', () => {
+            });
+
             const deleteButton = document.createElement('div');
             deleteButton.classList.add('delete-button');
             deleteButton.innerHTML = 'X';
+
+            // 삭제 버튼 클릭 시 해당 파일을 finalImageFiles 배열에서 찾아 삭제
             deleteButton.addEventListener('click', () => {
-                selectedImageFiles.splice(0, 1);
-                previewWrapper.remove();
-                if (selectedImageFiles.length === 0) {
-                    addImageButton.classList.remove('active');
-                    imagePreviewContainer.classList.remove('has-image');
+                const fileToRemove = file;
+
+                const indexToRemove = finalImageFiles.findIndex(f => f === fileToRemove);
+
+                if (indexToRemove !== -1) {
+                    finalImageFiles.splice(indexToRemove, 1);
                 }
+
+                // 삭제 후 미리보기를 다시 그림
+                redrawAllPreviews();
             });
 
             previewWrapper.appendChild(img);
@@ -136,16 +251,19 @@ export function initForumWrite() {
             imagePreviewContainer.appendChild(previewWrapper);
         };
         reader.readAsDataURL(file);
-
-        // 이미지 아이콘 색상 및 배경 표시
-        addImageButton.classList.add('active');
-        imagePreviewContainer.classList.add('has-image');
     }
 
-    // 텍스트 입력에 따라 버튼 활성화/비활성화
+    // 텍스트 입력에 따라 버튼 활성화/비활성화 (게시글 등록의 관건은 텍스트만!)
     contentInput.addEventListener('input', () => {
-        // 입력 필드의 공백을 제거한 길이가 0보다 크면
-        if (contentInput.value.trim().length > 0) {
+
+        // 텍스트 카운터 및 유효성 검사 수행
+        updateTextCounter();
+
+        const currentLength = contentInput.value.length;
+        const isTextValid = currentLength > 0 && currentLength <= MAX_TEXT_LENGTH;
+
+        // 텍스트가 유효할 때만 버튼 활성화
+        if (isTextValid) {
             submitButton.disabled = false; // 버튼 활성화
         } else {
             submitButton.disabled = true;  // 그렇지 않으면 버튼 비활성화
@@ -156,19 +274,32 @@ export function initForumWrite() {
     submitButton.addEventListener('click', async (e) => {
         e.preventDefault();
 
-        // 텍스트 유효성 검사 로직
+        // 텍스트 유효성 재확인 (submit 직전에 최종 검사)
         const content = document.getElementById("content").value.trim();
-        if (!content) {
-            showToast('게시글 내용을 입력해주세요.');
+        if (!content || content.length > MAX_TEXT_LENGTH) {
+            showToast('게시글 내용을 3000자 이내로 입력해주세요.');
+            submitButton.disabled = false;
+            submitButton.textContent = '공유';
+            return;
+        }
+
+        // 크롭이 진행 중이면 제출을 막습니다.
+        if (imagesToCropQueue.length > 0 || currentFileBeingCropped) {
+            showToast('이미지 편집을 완료하거나 취소해주세요.');
+            submitButton.disabled = false;
+            submitButton.textContent = '공유';
             return;
         }
 
         submitButton.disabled = true;
         submitButton.textContent = '업로드 중...';
 
-        const {value: currentAreaKey} = await Preferences.get({key: 'currentAreaKey'});
-        if (!currentAreaKey) {
-            showToast('지역 설정이 필요합니다.');
+        const {value: postingAreaKey} = await Preferences.get({key: 'viewingAreaKey'});
+        const {value: actualAreaKey} = await Preferences.get({key: 'currentAreaKey'});
+
+        // 지역 키가 유효하지 않으면 작성 차단
+        if (!postingAreaKey || postingAreaKey !== actualAreaKey) {
+            showToast('작성 가능한 지역이 아닙니다.');
             submitButton.disabled = false;
             submitButton.textContent = '공유';
             return;
@@ -176,9 +307,9 @@ export function initForumWrite() {
 
         let imageUrls = [];
         try {
-            if (selectedImageFiles.length > 0) {
+            if (finalImageFiles.length > 0) {
                 const formData = new FormData();
-                selectedImageFiles.forEach(file => {
+                finalImageFiles.forEach(file => {
                     formData.append("images", file);
                 });
 
@@ -189,8 +320,13 @@ export function initForumWrite() {
                 });
 
                 if (!imageUploadResponse.ok) {
-                    const errorData = await imageUploadResponse.json();
-                    throw new Error(errorData.message || "이미지 업로드에 실패했습니다.");
+                    const contentType = imageUploadResponse.headers.get("content-type");
+                    let errorMessage = "이미지 업로드에 실패했습니다.";
+                    if (contentType && contentType.includes("application/json")) {
+                        const errorData = await imageUploadResponse.json();
+                        errorMessage = errorData.message || errorMessage;
+                    }
+                    throw new Error(errorMessage);
                 }
 
                 const responseData = await imageUploadResponse.json();
@@ -207,7 +343,7 @@ export function initForumWrite() {
         // 2단계: 게시글 데이터와 이미지 URL 목록을 함께 전송
         const createForumData = {
             content: document.getElementById("content").value,
-            location: currentAreaKey,
+            location: postingAreaKey,
             imageUrls: imageUrls,
             userEmail: "test@gmail.com",
         };

--- a/src/main/resources/static/css/forum-area-search.css
+++ b/src/main/resources/static/css/forum-area-search.css
@@ -1,46 +1,47 @@
 #page-forum-area-search #app-container {
-    padding-top: 0;
+    padding-top: calc(40px + env(safe-area-inset-top, 0px));
     padding-left: 15px;
     padding-right: 15px;
 }
 
-/* 검색 페이지 헤더 */
 .search-header {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
+    justify-content: space-between;
+    position: fixed;
+    font-weight: 800;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
     width: 100%;
-    padding: 15px 0; /* 좌우 패딩 제거 */
-    border-bottom: 1px solid #ddd;
-}
-
-.back-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 5px;
-    display: flex;
-    align-items: center;
-    color: #333;
-}
-
-.back-button svg {
-    width: 24px;
-    height: 24px;
+    max-width: 400px;
+    z-index: 950;
+    padding: calc(10px + env(safe-area-inset-top, 0px)) 5px 10px 5px;
 }
 
 .header-title {
-    margin: 0;
-    margin-left: 20px;
-    font-size: 1.2em;
+    font-size: 1.3rem;
+    font-weight: 900;
     color: #333;
-    font-weight: bold;
+    flex-grow: 1; /* 제목이 남은 공간을 차지하여 중앙에 배치 */
+    text-align: center;
+    margin-left: 0;
+}
+
+.icon-button {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 5px;
+    color: #333;
+    margin-left: 16px;
 }
 
 /* 검색바 */
 .search-bar {
     width: 100%; /* 부모 컨테이너의 너비를 100%로 채움 */
-    margin: 20px 0;
+    margin: 30px 0 20px 0;
 }
 
 .input-wrapper {

--- a/src/main/resources/static/css/forum-edit.css
+++ b/src/main/resources/static/css/forum-edit.css
@@ -5,48 +5,77 @@
     color: #333;
     display: flex;
     flex-direction: column;
+    height: 100%;
+    min-height: 100svh;
+    width: 100%;
 }
 
 /* 폼 스타일링: header와 main, footer를 수직으로 배치 */
 #edit-forum-form {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
+    min-height: 100svh;
 }
 
 .header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 10px 15px;
     background-color: #E0E0E0;
+    position: fixed;
+    font-weight: 800;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 400px;
+    z-index: 950;
+    padding: calc(10px + env(safe-area-inset-top, 0px)) 5px 10px 5px;
 }
 
 .header-title {
-    font-size: 1rem;
+    font-size: 1.3rem;
     font-weight: 900;
     color: #333;
     flex-grow: 1; /* 제목이 남은 공간을 차지하여 중앙에 배치 */
-    text-align: left;
-    margin-left: 20px;
+    text-align: center;
+    margin-left: 0;
 }
 
 .icon-button {
     background: none;
     border: none;
-    font-size: 1rem;
+    font-size: 1.5rem;
     cursor: pointer;
     padding: 5px;
     color: #333;
+    margin-left: 16px;
 }
+
+.edit-toolbar-top {
+    display: flex;
+    justify-content: flex-end; /* 카운터를 오른쪽으로 밈 */
+    align-items: center;
+    padding: 15px 15px 5px 15px; /* 상하좌우 여백 */
+    background-color: #E0E0E0;
+    margin-top: calc(105px + env(safe-area-inset-top, 0px));
+}
+
+#text-count-display {
+    font-size: 0.85rem;
+    color: #666;
+}
+
 
 /* 텍스트 작성 영역 스타일링 */
 .writing-area {
+    width: 350px;
     flex-grow: 1;
-    padding: 40px 20px 0 20px;
     display: flex;
     flex-direction: column;
     position: relative;
+    margin-top: 10px;
 }
 
 .writing-area label {
@@ -55,14 +84,14 @@
     background-color: #fff;
     border-radius: 9px 9px 0 0;
     box-shadow: none;
-    padding: 15px;
+    padding: 25px 30px;
 }
 
 .writing-area #content {
     width: 100%;
     height: 100%;
     border: none;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 500;
     resize: none;
     outline: none;
@@ -76,32 +105,34 @@
 /* 하단 공유 버튼 스타일링 (forum-write.css 스타일 적용) */
 .submit-button {
     position: absolute;
-    bottom: 30px;
+    bottom: 60px;
     left: 50%;
     transform: translateX(-50%);
-    width: 300px;
+    width: 330px;
     max-width: none;
-    padding: 8px 20px;
-    border-radius: 5px;
+    padding: 10px 15px;
+    border-radius: 8px;
     border: none;
+    background-color: #ddd;
+    color: #fff;
     font-size: 0.9rem;
     font-weight: bold;
     text-align: center;
     cursor: not-allowed;
-    align-self: center;
-    transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
+    align-self: center; /* 가운데 정렬 */
+    transition: background-color 0.3s, box-shadow 0.3s;
 }
 
 .submit-button:disabled {
     background-color: #ddd;
     color: #fff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .submit-button:not(:disabled) {
     background-color: #72966a;
     color: #fff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     cursor: pointer;
 }
 
@@ -113,15 +144,15 @@
 
 /* 이미지 미리보기 컨테이너 및 삭제 버튼 스타일 */
 .image-preview-container {
-    position: absolute;
-    bottom: 80px; /* 공유 버튼과의 간격 조정 */
+    position: absolute;;
+    bottom: 130px; /* 공유 버튼과의 간격 조정 */
     left: 0;
     right: 0;
     width: auto;
     background-color: transparent;
     display: flex;
     gap: 10px;
-    padding: 10px 20px;
+    padding: 20px 22px;
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
     overflow-x: auto;
@@ -141,8 +172,8 @@
 }
 
 .img-preview {
-    width: 80px;
-    height: 80px;
+    width: 60px;
+    height: 60px;
     object-fit: cover;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -152,8 +183,8 @@
     position: absolute;
     top: 5px;
     right: 5px;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     background-color: rgba(0, 0, 0, 0.4);
     color: #fff;
     border-radius: 50%;
@@ -164,7 +195,6 @@
     cursor: pointer;
     backdrop-filter: blur(2px);
 }
-
 
 /* Toast 알림창 */
 .toast-container {

--- a/src/main/resources/static/css/forum-write.css
+++ b/src/main/resources/static/css/forum-write.css
@@ -5,47 +5,68 @@
     color: #333;
     display: flex;
     flex-direction: column;
+    height: 100%;
+    min-height: 100svh;
+    width: 100%;
 }
 
 /* 폼 스타일링: header와 main, footer를 수직으로 배치 */
 #forum-form {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
+    min-height: 100svh;
 }
 
 .header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 10px 15px;
     background-color: #E0E0E0;
+    position: fixed;
+    font-weight: 800;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100%;
+    max-width: 400px; /* index.css max-width 가정 */
+    z-index: 950;
+    padding: calc(10px + env(safe-area-inset-top, 0px)) 5px 10px 5px;
+
 }
 
 .header-title {
-    font-size: 1rem;
+    font-size: 1.3rem;
     font-weight: 900;
     color: #333;
     flex-grow: 1; /* 제목이 남은 공간을 차지하여 중앙에 배치 */
-    text-align: left;
-    margin-left: 20px;
+    text-align: center;
+    margin-left: 0;
 }
 
 .icon-button {
     background: none;
     border: none;
-    font-size: 1rem;
+    font-size: 1.5rem;
     cursor: pointer;
     padding: 5px;
     color: #333;
+    margin-left: 16px;
 }
 
 .toolbar-top {
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: 15px;
-    padding: 70px 10px 5px 30px;
+    padding: 50px 10px 20px 0;
+    margin-top: calc(50px + env(safe-area-inset-top, 0px));
+}
+
+#text-count-display {
+    margin-left: auto;
+    font-size: 0.85rem;
+    color: #333;
+    padding-right: 15px; /* 화면 우측 끝에서 약간의 여백 확보 */
 }
 
 .toolbar-top .icon-button {
@@ -53,6 +74,7 @@
     border: none;
     font-size: 1.3rem;
     cursor: pointer;
+    margin-right: 7px;
     padding: 8px; /* 아이콘과 배경 사이의 여백 */
     border-radius: 50%; /* 원형 배경 */
     color: #333;
@@ -64,8 +86,8 @@
 
 /* 텍스트 작성 영역 스타일링 */
 .writing-area {
+    width: 350px;
     flex-grow: 1;
-    padding: 8px 20px 0 20px;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -77,7 +99,7 @@
     background-color: #fff;
     border-radius: 9px 9px 0 0;
     box-shadow: none;
-    padding: 15px;
+    padding: 25px 30px;
 }
 
 .writing-area #content {
@@ -98,13 +120,13 @@
 /* 하단 공유 버튼 스타일링 */
 .submit-button {
     position: absolute;
-    bottom: 30px;
+    bottom: 60px;
     left: 50%;
     transform: translateX(-50%);
-    width: 300px; /* 더 짧은 너비로 변경 */
-    max-width: none; /* 최대 너비 제한을 없앱니다. */
-    padding: 8px 20px;
-    border-radius: 5px;
+    width: 330px;
+    max-width: none;
+    padding: 10px 15px;
+    border-radius: 8px;
     border: none;
     background-color: #ddd;
     color: #fff;
@@ -119,13 +141,13 @@
 .submit-button:disabled {
     background-color: #ddd; /* 비활성화 시 배경색 */
     color: #fff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .submit-button:not(:disabled) {
     background-color: #72966a;
     color: #fff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     cursor: pointer;
 }
 
@@ -138,14 +160,14 @@
 /* 이미지 미리보기 컨테이너 및 삭제 버튼 스타일 */
 .image-preview-container {
     position: absolute;;
-    bottom: 80px; /* 공유 버튼과의 간격 조정 */
+    bottom: 130px; /* 공유 버튼과의 간격 조정 */
     left: 0;
     right: 0;
     width: auto;
     background-color: transparent;
     display: flex;
     gap: 10px;
-    padding: 10px 20px;
+    padding: 20px 22px;
     white-space: nowrap;
     -webkit-overflow-scrolling: touch;
     overflow-x: auto;
@@ -165,8 +187,8 @@
 }
 
 .img-preview {
-    width: 80px;
-    height: 80px;
+    width: 60px;
+    height: 60px;
     object-fit: cover;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -176,8 +198,8 @@
     position: absolute;
     top: 5px;
     right: 5px;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
     background-color: rgba(0, 0, 0, 0.4);
     color: #fff;
     border-radius: 50%;
@@ -188,7 +210,6 @@
     cursor: pointer;
     backdrop-filter: blur(2px); /* 투명한 회색 배경 */
 }
-
 
 /* Toast 알림창 */
 .toast-container {

--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -7,9 +7,11 @@ html, body {
     padding: 0;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: stretch;
     background-color: #f0f2f5;
-    overflow: hidden; /* 스크롤바를 제거하여 앱처럼 보이게 함 */
+    overflow-y: auto;
+    font-family: Pretendard, sans-serif;
+    -webkit-tap-highlight-color: transparent;
 }
 
 /* 앱 화면 컨테이너 */
@@ -19,6 +21,7 @@ html, body {
     max-width: 400px; /* PC 등 큰 화면에서 너무 커지는 것을 방지 */
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     background-color: #fff;
+    padding: 16px;
 
     position: relative;
 
@@ -26,21 +29,21 @@ html, body {
 
     display: flex;
     flex-direction: column;
-    justify-content: center; /* 폼을 수직으로 중앙 정렬 */
+    justify-content: flex-start;
     align-items: center;
 }
 
-/* 로그인 */
-#page-login #app-container {
-    padding: 16px;
-}
-
-#page-signup #app-container {
-    padding: 20px;
-}
 
 /* 메인 페이지용 스타일 */
 #page-main #app-container {
-    justify-content: flex-start;
     align-items: stretch;
+}
+
+#page-main-nav #app-container {
+    padding: 16px;
+}
+
+#page-login #app-container,
+#page-signup #app-container {
+    justify-content: center;
 }

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -13,7 +13,7 @@
 }
 
 .logo img {
-    height: 40px;
+    height: 50px;
     width: auto;
     object-fit: contain;
 }

--- a/src/main/resources/static/css/main-nav.css
+++ b/src/main/resources/static/css/main-nav.css
@@ -1,7 +1,7 @@
 :root {
     --primary-color: #46825C;
     --sub-text-color: #777;
-    --border-color: #ddd;
+    --border-color: #F0F0F0;
 }
 
 .main-nav-bar {
@@ -14,9 +14,9 @@
 
     background-color: #fff;
     border-top: 1px solid var(--border-color);
-    padding: 10px 0;
-    box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.1);
-    z-index: 1010; /* [유지] 가장 위에 위치 (조건 2 만족) */
+    padding: 16px;
+    box-shadow: 0 0 1px rgba(0, 0, 0, 0.05);
+    z-index: 1010; /* 가장 위에 위치 */
 }
 
 /* 네비게이션 아이콘 영역 (유지) */
@@ -38,6 +38,9 @@
     padding: 5px 10px;
     position: relative;
     transition: color 0.3s ease-in-out;
+
+    /* 클릭 시 파란색 하이라이트 제거 */
+    -webkit-tap-highlight-color: transparent;
 }
 
 /* 폰트 어썸 아이콘의 색상 변경 (유지) */
@@ -68,7 +71,7 @@
     /* UI 디자인: 반투명 배경, 둥근 모서리, 그림자 */
     width: 90%;
     max-width: 250px;
-    padding: 15px 20px;
+    padding: 15px 10px;
     border-radius: 12px;
 
     /* [핵심: 반투명 배경] */
@@ -103,9 +106,15 @@
     flex-direction: column;
     align-items: center;
     text-decoration: none;
-    color: var(--primary-color); /* 활성화 색상 사용 */
+    color: var(--sub-text-color);
     opacity: 0.8;
     transition: opacity 0.2s;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.toggle-item:hover,
+.toggle-item:focus {
+    color: var(--primary-color);
 }
 
 .toggle-item:hover {

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -14,26 +14,57 @@ html, body {
     --shadow-color: rgba(0, 0, 0, 0.1);
 }
 
+#post-list-container.empty-list {
+    display: flex; /* 플렉스 컨테이너로 만듭니다. */
+    flex-direction: column; /* 내용을 세로로 정렬합니다. */
+    justify-content: center; /* 세로 중앙 정렬 (가운데로 밀어줍니다) */
+    align-items: center; /* 가로 중앙 정렬 */
+
+    min-height: 80vh;
+
+    width: 100%;
+    padding: 0; /* 패딩 제거 (중앙 정렬에 방해될 수 있습니다) */
+}
+
+/* 빈 게시글 컨테이너의 내부 텍스트 및 아이콘 정렬 */
+.empty-forum-container {
+    text-align: center; /* 내부 텍스트를 중앙 정렬합니다. */
+}
+
+/* 게시글이 있을 때 (#post-list-container에 .empty-list가 없을 때) */
+#post-list-container {
+    display: block; /* 또는 flex; flex-direction: column; justify-content: flex-start; */
+    padding: 1px; /* 게시글 목록에 적절한 패딩을 다시 설정합니다. (필요하다면) */
+    min-height: auto; /* 높이 제한을 해제합니다. */
+}
+
 .main-container {
     padding-bottom: 60px;
     display: flex;
     flex-direction: column;
     flex-grow: 1;
-    position: relative; /* 내부 콘텐츠(게시글, 네비바)를 배치하기 위해 flex 속성 */
+    position: relative;
+    width: 100%;
+    padding-top: calc(50px + env(safe-area-inset-top, 0px));
 }
 
 /* 상단 바 */
 .top-bar {
     display: flex;
-    height: 35px;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 20px;
     background-color: #fff;
-    border-bottom: 1px solid var(--border-color);
-    position: sticky;
+    border-bottom: 1px solid #F0F0F0;
+    position: fixed;
     top: 0;
     z-index: 1000;
+    width: 100%;
+    max-width: 400px;
+    padding: calc(5px + env(safe-area-inset-top, 0px)) 20px 3px 20px;
+    height: auto;
+
+    left: 50%;
+    transform: translateX(-50%);
 }
 
 /* 상단바 컨테이너 스타일 */
@@ -47,12 +78,14 @@ html, body {
 .logo {
     display: flex;
     align-items: center;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .logo img {
     height: 40px;
     width: 100px;
     object-fit: contain;
+    padding-left: 13px;
 }
 
 .location-area {
@@ -67,6 +100,8 @@ html, body {
     color: inherit;
     display: flex;
     align-items: center;
+    padding-right: 8px;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .location-icon {
@@ -103,7 +138,7 @@ html, body {
 
 .empty-text {
     font-size: 1.2em;
-    font-weight: bold;
+    font-weight: 800;
     margin-bottom: 10px;
 }
 
@@ -120,7 +155,7 @@ html, body {
     margin-bottom: 15px;
     overflow: hidden;
     position: relative;
-    width: 100%;
+    width: 380px;
 }
 
 /* 게시글 헤더 (작성자 정보 및 옵션) */
@@ -128,7 +163,7 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 15px;
+    padding: 15px 15px 10px 15px;
 }
 
 .post-author {
@@ -175,7 +210,7 @@ html, body {
 .post-image-carousel {
     position: relative;
     width: 100%;
-    padding-bottom: 75%;
+    padding-bottom: 133.33%;
     overflow: hidden;
     margin-bottom: 10px;
 }
@@ -363,9 +398,9 @@ html, body {
 /* 오른쪽에서 나타나는 모달 내용 컨테이너 */
 .comment-modal-content {
     background-color: #fff;
-    width: 70%;
-    max-width: 360px;
-    height: 60%;
+    width: 100%;
+    max-width: 350px;
+    height: 80%;
     border-top-left-radius: 20px;
     border-bottom-left-radius: 20px;
     box-shadow: -2px 0 10px rgba(0, 0, 0, 0.2);
@@ -558,7 +593,7 @@ html, body {
     border-radius: 8px;
     padding: 12px;
     position: fixed;
-    top: 50px; /* 변경: 화면 상단에 위치 */
+    top: 110px;
     left: 50%;
     transform: translateX(-50%);
     z-index: 9999;

--- a/src/main/resources/static/css/signup.css
+++ b/src/main/resources/static/css/signup.css
@@ -23,7 +23,7 @@
 }
 
 .logo img {
-    height: 40px;
+    height: 50px;
     width: auto;
     object-fit: contain;
 }
@@ -83,6 +83,7 @@
     flex-direction: column;
 }
 
+
 /* label 스타일 */
 label {
     font-weight: bold;
@@ -99,8 +100,14 @@ label {
     margin-bottom: 10px;
 }
 
+/*
 #passwordCheck {
     margin-bottom: 10px;
+}
+*/
+
+.input-group-nickname-group label {
+    margin-top: 10px;
 }
 
 .nickname-input-group {
@@ -132,7 +139,7 @@ label {
 
 /* 버튼 기본 스타일 */
 .btn {
-    padding: 8px;
+    padding: 10px;
     border-radius: 8px;
     cursor: pointer;
     font-weight: bold;

--- a/src/main/resources/templates/find/find-on-map.html
+++ b/src/main/resources/templates/find/find-on-map.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/main.css}">
     <link rel="stylesheet" th:href="@{/css/main-nav.css}">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 </head>
 <body id="page-on-map">

--- a/src/main/resources/templates/find/find-overwrite.html
+++ b/src/main/resources/templates/find/find-overwrite.html
@@ -5,8 +5,10 @@
     <title>Fin'd Overwrite</title>
     <link rel="stylesheet" th:href="@{/css/find-overwrite.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 </head>
-<body id="page-find-overwrite" data-find-url="${find_url}">
+<body data-find-url="${find_url}" id="page-find-overwrite">
 <div id="canvas-container">
     <canvas id="image-canvas"></canvas>
     <canvas id="paint-canvas"></canvas>

--- a/src/main/resources/templates/find/find-write.html
+++ b/src/main/resources/templates/find/find-write.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Fin'd</title>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" th:href="@{/css/find-write.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
 </head>

--- a/src/main/resources/templates/follow/friends.html
+++ b/src/main/resources/templates/follow/friends.html
@@ -7,6 +7,7 @@
 
     <!-- CSRF (null-safe) -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <meta content="" name="_csrf" th:attr="content=${_csrf?.token}"/>
     <meta content="X-CSRF-TOKEN" name="_csrf_header" th:attr="content=${_csrf?.headerName}"/>
     <link rel="stylesheet" th:href="@{/css/friends.css}">

--- a/src/main/resources/templates/forum/forum-area-search.html
+++ b/src/main/resources/templates/forum/forum-area-search.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>Forum Area Search</title>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/forum-area-search.css}">
@@ -12,13 +14,8 @@
 <body id="page-forum-area-search">
 <div id="app-container">
     <div class="search-header">
-        <button class="back-button">
-            <svg class="feather feather-arrow-left" fill="none" height="24" stroke="currentColor" stroke-linecap="round"
-                 stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="24"
-                 xmlns="http://www.w3.org/2000/svg">
-                <line x1="19" x2="5" y1="12" y2="12"></line>
-                <polyline points="12 19 5 12 12 5"></polyline>
-            </svg>
+        <button class="icon-button" id="back-btn" onclick="history.back()" type="button">
+            <i class="fas fa-chevron-left"></i>
         </button>
         <h2 class="header-title">지역 검색</h2>
     </div>

--- a/src/main/resources/templates/forum/forum-edit.html
+++ b/src/main/resources/templates/forum/forum-edit.html
@@ -5,30 +5,37 @@
     <title>forum-edit</title>
     <link href="https://fonts.googleapis.com" rel="preconnect">
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Agbalumo&family=Noto+Sans+KR:wght@400;700&display=swap"
-          rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <script defer th:src="@{/js/bundle.js}"></script>
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/forum-edit.css}">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 </head>
 <body id="page-forum-edit">
 <div id="app-container">
+
     <form id="edit-forum-form" th:object="${forum}">
         <input id="forum-id" th:value="*{id}" type="hidden">
+
         <header class="header">
-            <button class="icon-button" id="back-btn" type="button">
-                <i class="fas fa-arrow-left"></i>
+            <button class="icon-button" id="back-btn" onclick="history.back()" type="button">
+                <i class="fas fa-chevron-left"></i>
             </button>
-            <h1 class="header-title">Forum</h1>
+            <h1 class="header-title">수정하기</h1>
         </header>
+
+        <div class="edit-toolbar-top">
+            <span id="text-count-display">0/3000</span>
+        </div>
+
         <main class="writing-area">
             <label for="content">
                 <textarea id="content" name="content" th:text="*{contentsText}"></textarea>
             </label>
         </main>
+
         <div class="image-preview-container" id="image-preview-container">
             <div class="image-preview-wrapper" th:each="image : *{images}">
                 <img alt="게시물 사진" class="img-preview" th:src="${image.imgUrl}"/>

--- a/src/main/resources/templates/forum/forum-write.html
+++ b/src/main/resources/templates/forum/forum-write.html
@@ -3,16 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <title>forum-write</title>
-    <link href="https://fonts.googleapis.com" rel="preconnect">
-    <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Agbalumo&family=Noto+Sans+KR:wght@400;700&display=swap"
-          rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/forum-write.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css" rel="stylesheet">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
 </head>
@@ -21,9 +18,10 @@
     <form id="forum-form">
         <header class="header">
             <button class="icon-button" id="back-btn" onclick="history.back()" type="button">
-                <i class="fas fa-arrow-left"></i>
+                <i class="fas fa-chevron-left"></i>
             </button>
-            <h1 class="header-title">Forum</h1>
+            <h1 class="header-title">FORUM 작성</h1>
+            <div style="width: 40px; height: 30px;"></div>
         </header>
 
         <div class="toolbar-top">
@@ -31,6 +29,8 @@
                 <i class="fas fa-image"></i>
             </button>
             <input accept="image/*" id="images" multiple style="display: none;" type="file">
+            <span id="text-count-display">0/3000</span>
+
         </div>
 
         <main class="writing-area">

--- a/src/main/resources/templates/forum/main.html
+++ b/src/main/resources/templates/forum/main.html
@@ -5,9 +5,12 @@
     <title>Forum Main</title>
     <link href="https://fonts.googleapis.com" rel="preconnect">
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Agbalumo&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
+
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link href="/pwa/manifest.json" rel="manifest">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+
 
     <!-- [수정] 로그인 사용자(me) 정보를 JS 전역(window.__ME__)으로 주입합니다.
          - ForumController에서 model.addAttribute("me", ...)로 설정한 값을 직렬화합니다.
@@ -22,7 +25,6 @@
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/main.css}">
     <link rel="stylesheet" th:href="@{/css/main-nav.css}">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 </head>
 <body id="page-main">
 <div id="app-container">

--- a/src/main/resources/templates/notification/notification.html
+++ b/src/main/resources/templates/notification/notification.html
@@ -13,8 +13,8 @@
     <link rel="stylesheet" th:href="@{/css/main.css}">
     <link rel="stylesheet" th:href="@{/css/main-nav.css}">
     <link rel="stylesheet" th:href="@{/css/notification.css}">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-
     <!-- PWA -->
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <!-- 페이지 스크립트: 목록 로딩/읽음 처리/뱃지 갱신 수행 -->

--- a/src/main/resources/templates/park/park-write.html
+++ b/src/main/resources/templates/park/park-write.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" th:href="@{/css/park-write.css}">
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <script defer th:src="@{/js/bundle.js}"></script>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
 </head>
 <body id="page-park-write" th:data-nickname="${nickname}">
 <div id="app-container">

--- a/src/main/resources/templates/userInfo/login.html
+++ b/src/main/resources/templates/userInfo/login.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>로그인</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <script defer th:src="@{/js/bundle.js}"></script>

--- a/src/main/resources/templates/userInfo/profile.html
+++ b/src/main/resources/templates/userInfo/profile.html
@@ -6,6 +6,7 @@
     <title>Profile - PostHere</title>
     <meta name="_csrf" th:content="${_csrf?.token}"/>
     <meta name="_csrf_header" th:content="${_csrf?.headerName}"/>
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
     <link rel="manifest" th:href="@{/pwa/manifest.json}">
     <script defer th:src="@{/js/bundle.js}"></script>

--- a/src/main/resources/templates/userInfo/signup.html
+++ b/src/main/resources/templates/userInfo/signup.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <title>PostHere - 회원가입</title>
-
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css" rel="stylesheet"/>
     <link rel="stylesheet" th:href="@{/css/index.css}">
     <link rel="stylesheet" th:href="@{/css/signup.css}">
     <link rel="manifest" th:href="@{/pwa/manifest.json}">


### PR DESCRIPTION
## 구현 내용 요약
- 포럼 작성/수정 기능 안정화 및 유효성 검사 최종 통합
- 모바일 레이아웃(헤더, 텍스트 영역) 통일 및 간격 조정
- 네이티브 환경(Capacitor) 상태 표시줄 충돌 문제 최종 해결
- 
---

## 관련 이슈
Closes #140 

---

## 작업 상세 내역
- 텍스트/이미지 유효성: 텍스트 최대 길이 3000자 제한 및 이미지 최대 10장 제한 로직을 forum-write.js와 forum-edit.js에 통합.
- 실시간 카운터: forum-write에 실시간 텍스트 카운터를 구현하고, 텍스트가 비거나 초과할 경우 버튼 비활성화 및 경고 토스트 출력.
- 이미지 UX: 크롭 완료 후 원본 이미지 잔상 문제를 DOM 강제 리플로우를 통해 해결하고, 크롭 파일 포맷을 JPEG로 통일하여 업로드 안정성 확보.
- 수정 버튼 제어: forum-edit에서 텍스트가 공백이거나 유효하지 않을 때 수정 버튼 클릭 시 토스트 경고 출력.
- 헤더 통일: forum-edit 페이지의 상단 헤더(header)를 forum-write와 동일하게 position: fixed로 고정하고, 제목 중앙 정렬 및 뒤로가기 아이콘(<)의 크기/위치 조정.
- 게시글 비율: 메인 페이지의 게시글 이미지 비율을 가로가 긴 4:3에서 세로가 긴 3:4로 변경하여 작성 페이지와 시각적 통일성 확보.
- 레이아웃: forum-write/forum-edit의 텍스트 영역 너비를 화면 전체 너비로 확장하고, 헤더 및 툴바와의 간격을 미세 조정.
- 글꼴 통일: 프로젝트 전체에 Pretendard 폰트를 기본 글꼴로 설정하여 한/영 글꼴 굵기 및 디자인 일관성 확보.
- 상태 표시줄 (Status Bar) 고정: MainActivity.java에 최신 Java 코드를 삽입하여, JS 코드 실행과 무관하게 상태 표시줄 아이콘(시계/배터리)을 흰색 배경에 맞는 검은색(Dark)으로 강제 고정. (네이티브 테마 충돌 문제 최종 해결)

---

## from to
<fix/multi-image-fix-and-forum-api-refactor> -> <develop>

---