### PR TITLE
Fix/find and park UI

### DIFF
--- a/src/main/resources/static/css/find-write.css
+++ b/src/main/resources/static/css/find-write.css
@@ -1,23 +1,12 @@
 html {
     height: 100%;
 }
-body#page-find-write, #page-park-write {
+body#page-find-write, #page-park-write,
+body#page-find-overwrite, #page-park-overwrite { /* 기존 선택자는 그대로 두고 내용만 추가 */
     margin: 0;
-    background-color: lightgray;
-    width: 100%; /* html 태그의 width(360px)를 상속 */
-    height: 100%; /* html 태그의 height(780px)를 상속 */
-    position: relative; /* 자식 요소의 absolute 위치 기준이 되도록 설정 */
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    background-color: #404040;
-}
-body#page-find-overwrite, #page-park-overwrite {
-    margin: 0;
-    background-color: lightgray;
-    width: 100%; /* html 태그의 width(360px)를 상속 */
-    height: 100%; /* html 태그의 height(780px)를 상속 */
-    position: relative; /* 자식 요소의 absolute 위치 기준이 되도록 설정 */
+    width: 100%;
+    height: 100%;
+    position: relative;
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/src/main/resources/static/css/find-write.css
+++ b/src/main/resources/static/css/find-write.css
@@ -11,12 +11,16 @@ body#page-find-overwrite, #page-park-overwrite { /* 기존 선택자는 그대�
     flex-direction: column;
     justify-content: space-between;
     background-color: #404040;
+
+    padding-top: env(safe-area-inset-top);
+    box-sizing: border-box;
 }
 
 /* 1. div id="header-container" */
 #header-container {
     width: 100%;
     height: 42px;
+    position: relative;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## 구현 내용 요약
- Fin'd, Park 작성 시 헤더가 모바일 상태 표시줄과 겹치는 문제 해결
- find-write.css 파일 내 중복 코드 제거

---

## 관련 이슈
Closes #162 

---

## 작업 상세 내역
- 모바일 기기의 상태 표시줄만큼 페이지 상단에 padding 추가
- position: absolute가 적용된 바로 상위 요소에 position: relative 적용
- body 태그의 아이디에 따라 별도로 구현되어 있었으나, 실상은 동일한 속성 동합

---

## from to
`<feature/login>` -> `<main>`

---